### PR TITLE
Fix async watch replay, parser, and session-tail churn

### DIFF
--- a/packages/cli/dist/src/cli.js
+++ b/packages/cli/dist/src/cli.js
@@ -33,6 +33,11 @@ const OPENCLAWBRAIN_EMBEDDER_MODEL_ENV = "OPENCLAWBRAIN_EMBEDDER_MODEL";
 const OPENCLAWBRAIN_INSTALL_SKIP_EMBEDDER_PROVISION_ENV = "OPENCLAWBRAIN_INSTALL_SKIP_EMBEDDER_PROVISION";
 const LEGACY_COMPAT_PACKAGE_NAME = "@jonathangu/openclawbrain";
 const INSTALL_COMPATIBLE_LOCAL_TEACHER_MODEL_PREFIXES = [
+    "unsloth-qwen3.5-27b:q4_k_m",
+    "unsloth-qwen3.5-27b",
+    "qwen3.5:32b",
+    "qwen3.5:27b",
+    "qwen3.5:14b",
     "qwen3.5:9b",
     "qwen3.5:8b",
     "qwen3:8b",
@@ -5111,7 +5116,13 @@ function listWatchRuntimeEventExportBundleRoots(scanRoot) {
         .map((entry) => path.join(scanRoot, entry.name))
         .sort((left, right) => left.localeCompare(right));
 }
-async function replayWatchScanRootIntoTeacherLoop(teacherLoop, scanRoot) {
+async function replayWatchScanRootIntoTeacherLoop(teacherLoop, scanRoot, options = {}) {
+    if (options.skip === true) {
+        return {
+            replayedBundleCount: 0,
+            replayedEventCount: 0
+        };
+    }
     const seenExportDigests = new Set();
     const bundles = listWatchRuntimeEventExportBundleRoots(scanRoot)
         .map((rootDir) => {
@@ -5733,6 +5744,7 @@ export async function createWatchCommandRuntime(input) {
         const restoredSeenExportCount = restoredTeacherState.snapshot.state?.seenExportDigests.length ?? 0;
         log(`Restored teacher snapshot: seen=${restoredSeenExportCount} artifacts=${restoredTeacherState.snapshot.teacher.artifactCount}`);
     }
+    const restoredSeenExportCount = restoredTeacherState.snapshot?.state?.seenExportDigests.length ?? 0;
     const resolvedWatchProfileScope = input.profileRoots === undefined
         ? resolveWatchProfileRootsForActivationRoot(activationRoot)
         : {
@@ -5774,7 +5786,13 @@ export async function createWatchCommandRuntime(input) {
         replayedEventCount: 0
     };
     try {
-        replayState = await replayWatchScanRootIntoTeacherLoop(teacherLoop, scanRoot);
+        const skipStoredReplay = restoredSeenExportCount > 0 && startupWarnings.length === 0;
+        if (skipStoredReplay) {
+            log(`Stored replay skipped: restored teacher snapshot already tracks ${restoredSeenExportCount} export digest${restoredSeenExportCount === 1 ? "" : "s"}.`);
+        }
+        replayState = await replayWatchScanRootIntoTeacherLoop(teacherLoop, scanRoot, {
+            skip: skipStoredReplay
+        });
     }
     catch (error) {
         const message = formatWatchError(error);

--- a/packages/cli/dist/src/local-learner.js
+++ b/packages/cli/dist/src/local-learner.js
@@ -928,13 +928,15 @@ export function advanceAlwaysOnLearningRuntime(input) {
     const schedule = selectScheduledSlices(pending, current.learnedEventExport, cadence);
     const selectedSlices = schedule.selected;
     const learnedEventExport = mergeNormalizedEventExports(current.learnedEventExport, selectedSlices);
-    const runtimeGraphSnapshot = buildRuntimeGraphSnapshot({
-        ...input,
-        state: {
-            ...current,
-            structuralController
-        }
-    });
+    const runtimeGraphSnapshot = selectedSlices.length === 0
+        ? null
+        : buildRuntimeGraphSnapshot({
+            ...input,
+            state: {
+                ...current,
+                structuralController
+            }
+        });
     const runtimeGraph = runtimeGraphSnapshot?.graph ?? current.runtimeGraph;
     const runtimePlasticity = runtimeGraphSnapshot?.plasticity ?? current.runtimePlasticity;
     const sparseFeedbackObservedAt = input.builtAt ?? learnedEventExport?.range.lastCreatedAt ?? learnedEventExport?.range.firstCreatedAt ?? current.lastMaterializedAt ?? "1970-01-01T00:00:00.000Z";

--- a/packages/cli/dist/src/session-store.js
+++ b/packages/cli/dist/src/session-store.js
@@ -171,6 +171,35 @@ function parseOpenClawSessionRecord(value, lineNumber) {
                 timestamp: expectString(record.timestamp, `${lineNumber}.timestamp`)
             };
         }
+        case "compaction": {
+            const data = {};
+            if (record.summary !== undefined) {
+                data.summary = expectString(record.summary, `${lineNumber}.summary`);
+            }
+            if (record.firstKeptEntryId !== undefined) {
+                data.firstKeptEntryId = expectString(record.firstKeptEntryId, `${lineNumber}.firstKeptEntryId`);
+            }
+            if (record.tokensBefore !== undefined) {
+                data.tokensBefore = expectNumber(record.tokensBefore, `${lineNumber}.tokensBefore`);
+            }
+            if (record.details !== undefined) {
+                data.details = expectRecord(record.details, `${lineNumber}.details`);
+            }
+            if (record.fromHook !== undefined) {
+                if (typeof record.fromHook !== "boolean") {
+                    throw new Error(`${lineNumber}.fromHook must be a boolean`);
+                }
+                data.fromHook = record.fromHook;
+            }
+            return {
+                type: "custom",
+                customType: "openclaw.compaction",
+                data,
+                id: expectString(record.id, `${lineNumber}.id`),
+                parentId: expectNullableString(record.parentId, `${lineNumber}.parentId`),
+                timestamp: expectString(record.timestamp, `${lineNumber}.timestamp`)
+            };
+        }
         case "message":
             return {
                 type,
@@ -185,7 +214,9 @@ function parseOpenClawSessionRecord(value, lineNumber) {
 }
 function parseMessagePayload(value, path) {
     const payload = expectRecord(value, path);
-    const content = expectArray(payload.content, `${path}.content`).map((entry, index) => parseContentPart(entry, `${path}.content[${index}]`));
+    const content = typeof payload.content === "string"
+        ? [{ type: "text", text: payload.content }]
+        : expectArray(payload.content, `${path}.content`).map((entry, index) => parseContentPart(entry, `${path}.content[${index}]`));
     return {
         ...payload,
         role: expectString(payload.role, `${path}.role`),

--- a/packages/cli/dist/src/session-tail.js
+++ b/packages/cli/dist/src/session-tail.js
@@ -383,6 +383,7 @@ export class OpenClawLocalSessionTail {
         const firstPoll = this.initialized === false;
         const warnings = [];
         const changes = [];
+        const observedKeys = new Set();
         const sources = discoverOpenClawSessionStores({
             ...(this.homeDir === undefined ? {} : { homeDir: this.homeDir }),
             ...(this.profileRoots === undefined ? {} : { profileRoots: this.profileRoots })
@@ -409,9 +410,21 @@ export class OpenClawLocalSessionTail {
                     continue;
                 }
                 const key = cursorKey(source.indexPath, sessionKey);
+                observedKeys.add(key);
                 const existing = this.cursorBySession.get(key) ?? null;
                 const sessionFile = typeof entry.sessionFile === "string" && entry.sessionFile.trim().length > 0 ? path.resolve(entry.sessionFile) : null;
                 if (sessionFile === null) {
+                    const nextCursor = createCursor(source.indexPath, sessionKey, entry.sessionId, null, entry.updatedAt, 0, 0);
+                    this.cursorBySession.set(key, nextCursor);
+                    const changed = existing === null ||
+                        existing.sessionId !== entry.sessionId ||
+                        existing.sessionFile !== null ||
+                        existing.updatedAt !== entry.updatedAt ||
+                        existing.rawRecordCount !== 0 ||
+                        existing.bridgedEventCount !== 0;
+                    if (!changed) {
+                        continue;
+                    }
                     changes.push(createChange({
                         source,
                         sessionKey,
@@ -425,6 +438,17 @@ export class OpenClawLocalSessionTail {
                     continue;
                 }
                 if (!existsSync(sessionFile)) {
+                    const nextCursor = createCursor(source.indexPath, sessionKey, entry.sessionId, sessionFile, entry.updatedAt, 0, 0);
+                    this.cursorBySession.set(key, nextCursor);
+                    const changed = existing === null ||
+                        existing.sessionId !== entry.sessionId ||
+                        existing.sessionFile !== sessionFile ||
+                        existing.updatedAt !== entry.updatedAt ||
+                        existing.rawRecordCount !== 0 ||
+                        existing.bridgedEventCount !== 0;
+                    if (!changed) {
+                        continue;
+                    }
                     changes.push(createChange({
                         source,
                         sessionKey,
@@ -534,6 +558,17 @@ export class OpenClawLocalSessionTail {
                     scannedEventExport: deltaExport
                 }));
             }
+        }
+        let prunedCursorCount = 0;
+        for (const key of [...this.cursorBySession.keys()]) {
+            if (observedKeys.has(key)) {
+                continue;
+            }
+            this.cursorBySession.delete(key);
+            prunedCursorCount += 1;
+        }
+        if (prunedCursorCount > 0) {
+            warnings.push(`session tail pruned ${prunedCursorCount} stale cursor entr${prunedCursorCount === 1 ? "y" : "ies"}`);
         }
         this.initialized = true;
         const noopReason = firstPoll && !changes.some((change) => change.scannedEventExport !== null)

--- a/packages/cli/dist/test/session-store-custom-message.test.js
+++ b/packages/cli/dist/test/session-store-custom-message.test.js
@@ -64,3 +64,104 @@ test("readOpenClawSessionFile accepts custom_message session records", () => {
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("readOpenClawSessionFile accepts string-valued message.content payloads", () => {
+  const dir = makeTempDir();
+  const sessionFile = path.join(dir, "session.jsonl");
+  try {
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 1,
+          id: "session-1",
+          timestamp: "2026-04-01T00:00:00.000Z",
+          cwd: "/tmp",
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "msg-1",
+          parentId: null,
+          timestamp: "2026-04-01T00:00:01.000Z",
+          message: {
+            role: "assistant",
+            content: "Compacted answer body",
+            timestamp: 1711929601000,
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const records = readOpenClawSessionFile(sessionFile);
+    assert.equal(records.length, 2);
+    assert.deepEqual(records[1], {
+      type: "message",
+      id: "msg-1",
+      parentId: null,
+      timestamp: "2026-04-01T00:00:01.000Z",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Compacted answer body" }],
+        timestamp: 1711929601000,
+      },
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("readOpenClawSessionFile accepts compaction records", () => {
+  const dir = makeTempDir();
+  const sessionFile = path.join(dir, "session.jsonl");
+  try {
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 1,
+          id: "session-1",
+          timestamp: "2026-04-01T00:00:00.000Z",
+          cwd: "/tmp",
+        }),
+        JSON.stringify({
+          type: "compaction",
+          id: "cmp-1",
+          parentId: "msg-1",
+          timestamp: "2026-04-01T00:00:02.000Z",
+          summary: "Compacted prior context",
+          firstKeptEntryId: "msg-2",
+          tokensBefore: 2048,
+          details: {
+            readFiles: ["/tmp/file.md"],
+          },
+          fromHook: true,
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const records = readOpenClawSessionFile(sessionFile);
+    assert.equal(records.length, 2);
+    assert.deepEqual(records[1], {
+      type: "custom",
+      customType: "openclaw.compaction",
+      data: {
+        summary: "Compacted prior context",
+        firstKeptEntryId: "msg-2",
+        tokensBefore: 2048,
+        details: {
+          readFiles: ["/tmp/file.md"],
+        },
+        fromHook: true,
+      },
+      id: "cmp-1",
+      parentId: "msg-1",
+      timestamp: "2026-04-01T00:00:02.000Z",
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/dist/test/session-tail-custom-message.test.js
+++ b/packages/cli/dist/test/session-tail-custom-message.test.js
@@ -75,3 +75,135 @@ test("OpenClawLocalSessionTail tolerates custom_message session records", () => 
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("OpenClawLocalSessionTail stabilizes missing session-file states across polls", () => {
+  const root = makeTempDir();
+  const profileRoot = path.join(root, ".openclaw-smoke");
+  const sessionsDir = path.join(profileRoot, "agents", "main", "sessions");
+  mkdirSync(sessionsDir, { recursive: true });
+
+  const missingSessionFile = path.join(sessionsDir, "missing.jsonl");
+  try {
+    writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify(
+        {
+          session: {
+            sessionId: "session-1",
+            sessionFile: missingSessionFile,
+            updatedAt: 1,
+            chatType: "telegram",
+            origin: "test",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const tail = new OpenClawLocalSessionTail({ homeDir: root, emitExistingOnFirstPoll: true });
+    const first = tail.pollOnce({ observedAt: "2026-04-01T00:00:02.000Z" });
+    const second = tail.pollOnce({ observedAt: "2026-04-01T00:00:03.000Z" });
+
+    assert.equal(first.changes.length, 1);
+    assert.equal(first.changes[0].changeKind, "missing_session_file");
+    assert.equal(second.changes.length, 0);
+    assert.equal(second.cursor.length, 1);
+    assert.deepEqual(second.warnings, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("OpenClawLocalSessionTail stabilizes missing session-path states across polls", () => {
+  const root = makeTempDir();
+  const profileRoot = path.join(root, ".openclaw-smoke");
+  const sessionsDir = path.join(profileRoot, "agents", "main", "sessions");
+  mkdirSync(sessionsDir, { recursive: true });
+
+  try {
+    writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify(
+        {
+          session: {
+            sessionId: "session-1",
+            updatedAt: 1,
+            chatType: "telegram",
+            origin: "test",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const tail = new OpenClawLocalSessionTail({ homeDir: root, emitExistingOnFirstPoll: true });
+    const first = tail.pollOnce({ observedAt: "2026-04-01T00:00:02.000Z" });
+    const second = tail.pollOnce({ observedAt: "2026-04-01T00:00:03.000Z" });
+
+    assert.equal(first.changes.length, 1);
+    assert.equal(first.changes[0].changeKind, "missing_session_path");
+    assert.equal(second.changes.length, 0);
+    assert.equal(second.cursor.length, 1);
+    assert.deepEqual(second.warnings, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("OpenClawLocalSessionTail prunes stale cursor entries when sessions disappear from the index", () => {
+  const root = makeTempDir();
+  const profileRoot = path.join(root, ".openclaw-smoke");
+  const sessionsDir = path.join(profileRoot, "agents", "main", "sessions");
+  mkdirSync(sessionsDir, { recursive: true });
+
+  const sessionFile = path.join(sessionsDir, "session.jsonl");
+  try {
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 1,
+          id: "session-1",
+          timestamp: "2026-04-01T00:00:00.000Z",
+          cwd: "/tmp",
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify(
+        {
+          session: {
+            sessionId: "session-1",
+            sessionFile,
+            updatedAt: 1,
+            chatType: "telegram",
+            origin: "test",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const tail = new OpenClawLocalSessionTail({ homeDir: root, emitExistingOnFirstPoll: true });
+    const first = tail.pollOnce({ observedAt: "2026-04-01T00:00:02.000Z" });
+    assert.equal(first.cursor.length, 1);
+
+    writeFileSync(path.join(sessionsDir, "sessions.json"), JSON.stringify({}, null, 2), "utf8");
+    const second = tail.pollOnce({ observedAt: "2026-04-01T00:00:03.000Z" });
+
+    assert.equal(second.changes.length, 0);
+    assert.equal(second.cursor.length, 0);
+    assert.deepEqual(second.warnings, ["session tail pruned 1 stale cursor entry"]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/dist/test/watch-reliability-regressions.test.js
+++ b/packages/cli/dist/test/watch-reliability-regressions.test.js
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function loadFunction({ file, startMarker, endMarker, prelude = "" }) {
+  const source = readFileSync(path.join(__dirname, "..", "src", file), "utf8");
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker, start);
+  if (start === -1 || end === -1) {
+    throw new Error(`failed to locate ${startMarker} in ${file}`);
+  }
+  const block = source.slice(start, end).replace(/^export\s+/gmu, "");
+  const match = /function\s+([A-Za-z0-9_]+)/u.exec(startMarker);
+  if (match === null) {
+    throw new Error(`failed to extract function name from ${startMarker}`);
+  }
+  return new Function(`${prelude}\n${block}\nreturn ${match[1]};`)();
+}
+
+test("watch replay guard can skip stored replay without touching bundle roots", async () => {
+  globalThis.__ocbReplayHarness = {
+    listCalls: 0,
+    loadCalls: [],
+    roots: ["/tmp/export-a"],
+    bundles: {
+      "/tmp/export-a": {
+        manifest: { exportedAt: "2026-04-01T00:00:00.000Z" },
+        normalizedEventExport: {
+          range: { start: 1, end: 1, count: 1 },
+          provenance: { exportDigest: "sha256-a" },
+        },
+      },
+    },
+  };
+  const replayWatchScanRootIntoTeacherLoop = loadFunction({
+    file: "cli.js",
+    startMarker: "async function replayWatchScanRootIntoTeacherLoop",
+    endMarker: "function exportLocalSessionTailChangesToScanRoot",
+    prelude: `
+      const __harness = globalThis.__ocbReplayHarness;
+      function listWatchRuntimeEventExportBundleRoots(scanRoot) {
+        __harness.listCalls += 1;
+        return __harness.roots;
+      }
+      function loadRuntimeEventExportBundle(rootDir) {
+        __harness.loadCalls.push(rootDir);
+        return __harness.bundles[rootDir];
+      }
+    `,
+  });
+  const teacherLoop = {
+    enqueueNormalizedEventExport() {
+      throw new Error("skip replay should not enqueue exports");
+    },
+    async flush() {
+      throw new Error("skip replay should not flush");
+    },
+  };
+
+  const result = await replayWatchScanRootIntoTeacherLoop(teacherLoop, "/tmp/scan-root", { skip: true });
+
+  assert.deepEqual(result, {
+    replayedBundleCount: 0,
+    replayedEventCount: 0,
+  });
+  assert.equal(globalThis.__ocbReplayHarness.listCalls, 0);
+  assert.deepEqual(globalThis.__ocbReplayHarness.loadCalls, []);
+  delete globalThis.__ocbReplayHarness;
+});
+
+test("teacher autodetect prefers larger compatible qwen lanes when available", () => {
+  const selectCompatibleLocalTeacherModel = loadFunction({
+    file: "cli.js",
+    startMarker: "function selectCompatibleLocalTeacherModel",
+    endMarker: "function detectInstallTeacherDefaults",
+    prelude: `
+      const INSTALL_COMPATIBLE_LOCAL_TEACHER_MODEL_PREFIXES = [
+        "unsloth-qwen3.5-27b:q4_k_m",
+        "unsloth-qwen3.5-27b",
+        "qwen3.5:32b",
+        "qwen3.5:27b",
+        "qwen3.5:14b",
+        "qwen3.5:9b",
+        "qwen3.5:8b",
+        "qwen3:8b",
+        "qwen2.5:7b",
+      ];
+    `,
+  });
+
+  const selected = selectCompatibleLocalTeacherModel([
+    "qwen3.5:9b",
+    "unsloth-qwen3.5-27b:q4_k_m",
+    "qwen3.5:14b",
+  ]);
+
+  assert.equal(selected, "unsloth-qwen3.5-27b:q4_k_m");
+});
+
+test("advanceAlwaysOnLearningRuntime does not rebuild the runtime graph on empty selected slices", () => {
+  globalThis.__ocbAdvanceHarness = {
+    buildCalls: 0,
+    learnedEventExport: null,
+    initialState: {
+      runtimeOwner: "openclaw",
+      hotPathLearning: false,
+      attachBlocksOnFullReplay: false,
+      cursor: { watermark: 1 },
+      pending: { live: [], backfill: [] },
+      learnedEventExport: null,
+      runtimeGraph: { packId: "existing-graph" },
+      runtimePlasticity: { strongestBlockId: "blk-1" },
+      learnedGraph: null,
+      structuralController: { structuralOps: [] },
+      sparseFeedback: { mode: "default" },
+      lastMaterializedAt: "2026-04-01T00:00:00.000Z",
+      materializationCount: 0,
+    },
+  };
+  const advanceAlwaysOnLearningRuntime = loadFunction({
+    file: "local-learner.js",
+    startMarker: "export function advanceAlwaysOnLearningRuntime",
+    endMarker: "export function drainAlwaysOnLearningRuntime",
+    prelude: `
+      const __harness = globalThis.__ocbAdvanceHarness;
+      function normalizeAlwaysOnLearningCadence(value) { return value ?? { mode: "default" }; }
+      function cloneAlwaysOnLearningRuntimeState(value) { return JSON.parse(JSON.stringify(value)); }
+      function createAlwaysOnLearningRuntimeState() { return JSON.parse(JSON.stringify(__harness.initialState)); }
+      function resolveAlwaysOnLearningStructuralController(current) { return current ?? { structuralOps: [] }; }
+      function normalizeSparseFeedbackPolicy(value) { return value ?? { mode: "default" }; }
+      function buildNormalizedEventExportBridge() { return { cursor: { watermark: 1 }, slices: [] }; }
+      function mergePendingSlices(current) { return current; }
+      function selectScheduledSlices() { return { selected: [], remaining: { live: [], backfill: [] }, selectedBucket: "none" }; }
+      function mergeNormalizedEventExports(current) { return current; }
+      function buildRuntimeGraphSnapshot() {
+        __harness.buildCalls += 1;
+        return { graph: { packId: "rebuilt-graph" }, plasticity: { strongestBlockId: "blk-rebuilt" } };
+      }
+      function createSparseFeedbackRuntimeDiagnostics(policy) { return policy; }
+      function evaluateSparseFeedback(_feedbackEvents, _observedAt, policy) { return { diagnostics: policy }; }
+      function buildAlwaysOnLearningMaterializationJob() { throw new Error("no-op cycle should not materialize"); }
+      function summarizePrincipalBacklog() { return { principalCount: 0, pendingEventCount: 0, checkpoints: [], oldestUnlearnedEvent: null, newestPendingEvent: null }; }
+      function cloneNormalizedEventExportSlice(value) { return value; }
+    `,
+  });
+
+  const result = advanceAlwaysOnLearningRuntime({
+    packLabel: "watch-cli",
+    workspace: {
+      workspaceId: "watch-cli",
+      snapshotId: "watch-cli@test",
+      capturedAt: "2026-04-01T00:00:00.000Z",
+      rootDir: "/tmp",
+      revision: "watch-cli-v2",
+    },
+    interactionEvents: [{ eventId: "evt-1" }],
+    feedbackEvents: [],
+    learnedRouting: false,
+    state: globalThis.__ocbAdvanceHarness.initialState,
+  });
+
+  assert.equal(globalThis.__ocbAdvanceHarness.buildCalls, 0);
+  assert.equal(result.materialization, null);
+  assert.deepEqual(result.state.runtimeGraph, { packId: "existing-graph" });
+  assert.deepEqual(result.state.runtimePlasticity, { strongestBlockId: "blk-1" });
+  delete globalThis.__ocbAdvanceHarness;
+});


### PR DESCRIPTION
## Summary
- skip stored export replay when a restored teacher snapshot already tracks seen export digests
- stop rebuilding the runtime graph on no-op always-on learner cycles
- stabilize missing session-path/session-file cursor states and prune stale cursor entries
- expand session parsing to accept compaction records and string-valued `message.content`
- prefer larger compatible local Qwen teacher lanes during install autodetect

## Validation
- `npm test`
- `npm run release:verify`

Closes #7