### PR TITLE
Reduce status read amplification and isolate converge env

### DIFF
--- a/packages/cli/dist/src/cli.js
+++ b/packages/cli/dist/src/cli.js
@@ -21,7 +21,7 @@ import { describeOpenClawBrainHotfixBoundary, inspectOpenClawBrainHookStatus, in
 import { describeOpenClawBrainInstallIdentity, describeOpenClawBrainInstallLayout, findInstalledOpenClawBrainPlugin, getOpenClawBrainKnownPluginIds, normalizeOpenClawBrainPluginsConfig, pinInstalledOpenClawBrainPluginActivationRoot, quarantineOpenClawBrainNestedDuplicateInstalls, resolveOpenClawBrainInstallTarget } from "./openclaw-plugin-install.js";
 import { buildOpenClawBrainConvergeRestartPlan, classifyOpenClawBrainConvergeVerification, describeOpenClawBrainConvergeChangeReasons, diffOpenClawBrainConvergeRuntimeFingerprint, finalizeOpenClawBrainConvergeResult, planOpenClawBrainConvergePluginAction, shouldReplaceOpenClawBrainInstallBeforeConverge } from "./install-converge.js";
 import { loadAttachmentPolicyDeclaration, resolveEffectiveAttachmentPolicyTruth, writeAttachmentPolicyDeclaration } from "./attachment-policy-truth.js";
-import { DEFAULT_WATCH_POLL_INTERVAL_SECONDS, buildNormalizedEventExportFromScannedEvents, bootstrapRuntimeAttach, clearOpenClawProfileRuntimeLoadProof, compileRuntimeContext, createAsyncTeacherLiveLoop, createOpenClawLocalSessionTail, createRuntimeEventExportScanner, describeCurrentProfileBrainStatusWithReport, formatOperatorRollbackReport, listOpenClawProfileRuntimeLoadProofs, loadRuntimeEventExportBundle, loadWatchTeacherSnapshotState, persistWatchTeacherSnapshot, rollbackRuntimeAttach, resolveAttachmentRuntimeLoadProofsPath, resolveOperatorTeacherSnapshotPath, resolveAsyncTeacherLiveLoopSnapshotPath, resolveWatchSessionTailCursorPath, resolveWatchStateRoot, resolveWatchTeacherSnapshotPath, scanLiveEventExport, scanRecordedSession, summarizeLearningPathFromMaterialization, summarizeNormalizedEventExportLabelFlow, summarizeTeacherNoArtifactCycle, writeScannedEventExportBundle } from "./index.js";
+import { DEFAULT_WATCH_POLL_INTERVAL_SECONDS, buildNormalizedEventExportFromScannedEvents, bootstrapRuntimeAttach, clearOpenClawProfileRuntimeLoadProof, compileRuntimeContext, createAsyncTeacherLiveLoop, createOpenClawLocalSessionTail, createRuntimeEventExportScanner, describeCurrentProfileBrainStatus, describeCurrentProfileBrainStatusWithReport, formatOperatorRollbackReport, listOpenClawProfileRuntimeLoadProofs, loadRuntimeEventExportBundle, loadWatchTeacherSnapshotState, persistWatchTeacherSnapshot, rollbackRuntimeAttach, resolveAttachmentRuntimeLoadProofsPath, resolveOperatorTeacherSnapshotPath, resolveAsyncTeacherLiveLoopSnapshotPath, resolveWatchSessionTailCursorPath, resolveWatchStateRoot, resolveWatchTeacherSnapshotPath, scanLiveEventExport, scanRecordedSession, summarizeLearningPathFromMaterialization, summarizeNormalizedEventExportLabelFlow, summarizeTeacherNoArtifactCycle, writeScannedEventExportBundle } from "./index.js";
 import { appendLearningUpdateLogs } from "./learning-spine.js";
 import { buildPassiveLearningSessionExportFromOpenClawSessionStore } from "./local-session-passive-learning.js";
 import { reindexMaterializationCandidateWithEmbedder } from "./materialization-embedder.js";
@@ -1800,14 +1800,22 @@ function readInstallRuntimeFingerprint(openclawHome) {
         daemonRuntimeSource: daemonSurface?.surfaceIdentitySource ?? null
     };
 }
+function buildConvergePluginManagerEnv(openclawHome) {
+    const normalizedOpenClawHome = path.resolve(openclawHome);
+    const pluginManagerEnv = {
+        ...process.env,
+        OPENCLAW_HOME: normalizedOpenClawHome,
+        OPENCLAW_STATE_DIR: normalizedOpenClawHome,
+        OPENCLAW_CONFIG_PATH: path.join(normalizedOpenClawHome, "openclaw.json")
+    };
+    delete pluginManagerEnv.OPENCLAW_PROFILE;
+    return pluginManagerEnv;
+}
 function runOpenClawBrainConvergePluginStep(openclawHome) {
     const quarantinedNestedDuplicates = quarantineOpenClawBrainNestedDuplicateInstalls(openclawHome);
     const before = readInstallRuntimeFingerprint(openclawHome);
     const plan = planOpenClawBrainConvergePluginAction(before);
-    const pluginManagerEnv = {
-        ...process.env,
-        OPENCLAW_HOME: openclawHome
-    };
+    const pluginManagerEnv = buildConvergePluginManagerEnv(openclawHome);
     if (plan.action === "noop") {
         return {
             plan,
@@ -7523,12 +7531,11 @@ export function runOperatorCli(argv = process.argv.slice(2)) {
             : { profileId: targetInspection.profileId }),
         teacherSnapshotPath: resolveOperatorTeacherSnapshotPath(activationRoot, statusOrRollback.input.teacherSnapshotPath)
     };
-    const statusWithReport = describeCurrentProfileBrainStatusWithReport(operatorInput);
-    const status = statusWithReport.status;
     const tracedLearning = buildTracedLearningStatusSurface(activationRoot);
-    const normalizedStatusAndReport = applyAttachmentPolicyTruth(status, statusOrRollback.json ? null : statusWithReport.report);
-    const hotfixBoundaryTruth = summarizeStatusHotfixBoundary(normalizedStatusAndReport.status);
     if (statusOrRollback.json) {
+        const status = describeCurrentProfileBrainStatus(operatorInput);
+        const normalizedStatusAndReport = applyAttachmentPolicyTruth(status, null);
+        const hotfixBoundaryTruth = summarizeStatusHotfixBoundary(normalizedStatusAndReport.status);
         console.log(JSON.stringify({
             ...normalizedStatusAndReport.status,
             tracedLearning,
@@ -7536,6 +7543,8 @@ export function runOperatorCli(argv = process.argv.slice(2)) {
         }, null, 2));
     }
     else {
+        const statusWithReport = describeCurrentProfileBrainStatusWithReport(operatorInput);
+        const normalizedStatusAndReport = applyAttachmentPolicyTruth(statusWithReport.status, statusWithReport.report);
         const report = normalizedStatusAndReport.report;
         const providerConfig = readOpenClawBrainProviderConfigFromSources({
             env: process.env,

--- a/packages/cli/dist/src/index.js
+++ b/packages/cli/dist/src/index.js
@@ -3075,8 +3075,8 @@ export function deriveEmpiricalStructuralBudgetFromCompileSignals(input) {
         ]
     };
 }
-function resolveCompileBudget(target, input) {
-    const pack = loadPackFromActivation(target.activationRoot, "active");
+function resolveCompileBudget(target, input, options = {}) {
+    const pack = options.pack ?? loadPackFromActivation(target.activationRoot, "active");
     return deriveEmpiricalStructuralBudget({
         requestedStrategy: input.budgetStrategy ?? "empirical_v1",
         ...(input.maxContextBlocks !== undefined ? { requestedMaxContextBlocks: input.maxContextBlocks } : {}),
@@ -3177,7 +3177,8 @@ export function compileRuntimeContext(input) {
     try {
         const target = resolveActivePackForCompile(activationRoot);
         validateFrozenReplayEvalIdentity(target, frozenReplayEvalIdentity);
-        const resolvedBudget = resolveCompileBudget(target, input);
+        const activePack = loadPackFromActivation(activationRoot, "active", { requireActivationReady: true });
+        const resolvedBudget = resolveCompileBudget(target, input, { pack: activePack });
         routeSelectionStartedAtNs = monotonicClockNs();
         const compile = compileRuntimeFromActivation(activationRoot, {
             contract: CONTRACT_IDS.runtimeCompile,
@@ -3191,7 +3192,9 @@ export function compileRuntimeContext(input) {
             ...(runtimeHints.length > 0 ? { runtimeHints } : {})
         }, {
             ...(selectionMode !== undefined ? { selectionMode } : {}),
-            ...(learnedRouteSelectionOverride === null ? {} : { _learnedRouteSelectionOverride: learnedRouteSelectionOverride })
+            ...(learnedRouteSelectionOverride === null ? {} : { _learnedRouteSelectionOverride: learnedRouteSelectionOverride }),
+            pack: activePack,
+            target: describePackCompileTarget(activePack)
         });
         routeSelectionMs = elapsedMsFrom(routeSelectionStartedAtNs);
         const selectionEngine = selectionMode ?? "flat_rank_v1";
@@ -3569,7 +3572,8 @@ function buildAttachStatusCompileInput(activationRoot, compile) {
         ...(compile?.maxContextChars !== undefined ? { maxContextChars: compile.maxContextChars } : {}),
         ...(compile?.mode !== undefined ? { mode: compile.mode } : {}),
         ...(compile?.compactionMode !== undefined ? { compactionMode: compile.compactionMode } : {}),
-        runtimeHints: compile?.runtimeHints ?? [...DEFAULT_ATTACH_STATUS_RUNTIME_HINTS]
+        runtimeHints: compile?.runtimeHints ?? [...DEFAULT_ATTACH_STATUS_RUNTIME_HINTS],
+        _suppressServeLog: true
     };
 }
 export function describeAttachStatus(input) {
@@ -6111,7 +6115,7 @@ export function summarizeLearningPathFromMaterialization(materialization) {
         router: materialization.candidate.payloads.router
     });
 }
-function summarizeActivePackObservability(activationRoot, active) {
+function summarizeActivePackObservability(activationRoot, active, options = {}) {
     if (active === null) {
         return {
             labelFlow: buildMissingLabelFlowSummary("no active pack is attached"),
@@ -6125,7 +6129,10 @@ function summarizeActivePackObservability(activationRoot, active) {
         };
     }
     try {
-        const pack = loadPackFromActivation(activationRoot, "active", { requireActivationReady: true });
+        const pack = loadPackFromActivation(activationRoot, "active", {
+            requireActivationReady: true,
+            packCache: options.packCache
+        });
         if (pack === null) {
             return {
                 labelFlow: buildMissingLabelFlowSummary("active pack payloads are unavailable"),
@@ -6612,6 +6619,9 @@ function loadLatestOperatorEventExportFromScanRoots(scanRoots) {
     };
 }
 function loadOperatorEventExport(input) {
+    if (Object.prototype.hasOwnProperty.call(input, "__loadedOperatorEventExport")) {
+        return input.__loadedOperatorEventExport;
+    }
     const eventExportPath = normalizeOptionalString(input.eventExportPath);
     if (eventExportPath !== undefined) {
         return loadOperatorEventExportFromPath(path.resolve(eventExportPath));
@@ -6779,6 +6789,9 @@ function summarizeSupervision(input) {
     };
 }
 function loadTeacherSurfaceFromInput(input) {
+    if (Object.prototype.hasOwnProperty.call(input, "__loadedTeacherSurface")) {
+        return input.__loadedTeacherSurface;
+    }
     const teacherSnapshotPath = resolveOperatorTeacherSnapshotPath(input.activationRoot, normalizeOptionalString(input.teacherSnapshotPath) ?? null);
     if (teacherSnapshotPath === null) {
         return null;
@@ -8042,6 +8055,15 @@ export function buildOperatorSurfaceReport(input) {
     const activationRoot = path.resolve(normalizeNonEmptyString(input.activationRoot, "activationRoot"));
     const updatedAt = normalizeIsoTimestamp(input.updatedAt, "updatedAt", new Date().toISOString());
     const brainAttachmentPolicy = normalizeBrainAttachmentPolicy(input.brainAttachmentPolicy);
+    const resolvedTeacherSnapshotPath = resolveOperatorTeacherSnapshotPath(activationRoot, normalizeOptionalString(input.teacherSnapshotPath) ?? null);
+    const cachedInput = {
+        ...input,
+        activationRoot,
+        teacherSnapshotPath: resolvedTeacherSnapshotPath,
+        __loadedTeacherSurface: resolvedTeacherSnapshotPath === null ? null : loadTeacherSurface(resolvedTeacherSnapshotPath)
+    };
+    cachedInput.__loadedOperatorEventExport = loadOperatorEventExport(cachedInput);
+    const packCache = new Map();
     let inspection = null;
     let observability = null;
     let inspectionError = null;
@@ -8057,7 +8079,9 @@ export function buildOperatorSurfaceReport(input) {
     if (inspection !== null && inspection.active !== null) {
         try {
             observability = describeActivationObservability(activationRoot, "active", {
-                updatedAt
+                updatedAt,
+                inspection,
+                packCache
             });
         }
         catch (error) {
@@ -8073,7 +8097,7 @@ export function buildOperatorSurfaceReport(input) {
         inspectionError
     });
     const activeObservability = inspectionError === null
-        ? summarizeActivePackObservability(activationRoot, active)
+        ? summarizeActivePackObservability(activationRoot, active, { packCache })
         : {
             labelFlow: buildMissingLabelFlowSummary(`activation observability is unavailable: ${inspectionError}`),
             learningPath: buildMissingLearningPathSummary(`activation observability is unavailable: ${inspectionError}`)
@@ -8107,7 +8131,7 @@ export function buildOperatorSurfaceReport(input) {
         activePackId: active?.packId ?? null,
         learnedRouting
     });
-    const teacherLoop = summarizeTeacherLoop(input);
+    const teacherLoop = summarizeTeacherLoop(cachedInput);
     const hook = summarizeOperatorHook({
         activationRoot,
         openclawHome: normalizeOptionalString(input.openclawHome) ?? null,
@@ -8132,8 +8156,8 @@ export function buildOperatorSurfaceReport(input) {
         },
         brain: observability === null ? summarizeBrainStateWithoutObservability(active, activation) : summarizeBrainState(active, observability),
         graph: observability === null
-            ? summarizeGraphWithoutObservability(input, active, activation)
-            : summarizeGraphObservability(input, active, observability),
+            ? summarizeGraphWithoutObservability(cachedInput, active, activation)
+            : summarizeGraphObservability(cachedInput, active, observability),
         labelFlow: activeObservability.labelFlow,
         learningPath: activeObservability.learningPath,
         learnedRouting,
@@ -8157,13 +8181,13 @@ export function buildOperatorSurfaceReport(input) {
             previousPackId: inspection?.previous?.packId ?? inspection?.pointers.previous?.packId ?? null,
             state: inspection === null ? "unknown" : inspection.rollback.allowed ? "ready" : inspection.active === null ? "unknown" : "blocked"
         },
-        supervision: summarizeSupervision(input),
-        learning: summarizeAlwaysOnLearning(input, active),
+        supervision: summarizeSupervision(cachedInput),
+        learning: summarizeAlwaysOnLearning(cachedInput, active),
         teacherLoop,
         routeFn,
         hook,
         attachmentTruth,
-        principal: summarizePrincipalObservability(input, active),
+        principal: summarizePrincipalObservability(cachedInput, active),
         manyProfile: summarizeManyProfileSupport(brainAttachmentPolicy)
     };
     const findings = buildOperatorFindings(reportBase);

--- a/packages/cli/dist/test/operator-status-regressions.test.js
+++ b/packages/cli/dist/test/operator-status-regressions.test.js
@@ -1,0 +1,231 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function loadFunctionFromSourcePath({ sourcePath, startMarker, endMarker, prelude = "" }) {
+    const source = readFileSync(sourcePath, "utf8");
+    const start = source.indexOf(startMarker);
+    const end = source.indexOf(endMarker, start);
+    if (start === -1 || end === -1) {
+        throw new Error(`failed to locate ${startMarker} in ${sourcePath}`);
+    }
+    const block = source.slice(start, end).replace(/^export\s+/gmu, "");
+    const match = /function\s+([A-Za-z0-9_]+)/u.exec(startMarker);
+    if (match === null) {
+        throw new Error(`failed to extract function name from ${startMarker}`);
+    }
+    return new Function(`${prelude}\n${block}\nreturn ${match[1]};`)();
+}
+
+test("buildConvergePluginManagerEnv clears profile-pinned state and targets the requested home", () => {
+    globalThis.__ocbPath = path;
+    const buildConvergePluginManagerEnv = loadFunctionFromSourcePath({
+        sourcePath: path.join(__dirname, "..", "src", "cli.js"),
+        startMarker: "function buildConvergePluginManagerEnv",
+        endMarker: "function runOpenClawBrainConvergePluginStep",
+        prelude: `
+            const path = globalThis.__ocbPath;
+            const process = {
+                env: {
+                    OPENCLAW_PROFILE: "CormorantAI",
+                    OPENCLAW_STATE_DIR: "/tmp/profile-state",
+                    OPENCLAW_CONFIG_PATH: "/tmp/profile-state/openclaw.json",
+                    KEEP_ME: "yes"
+                }
+            };
+        `
+    });
+    const env = buildConvergePluginManagerEnv("/tmp/shared-home");
+    assert.equal(env.OPENCLAW_HOME, path.resolve("/tmp/shared-home"));
+    assert.equal(env.OPENCLAW_STATE_DIR, path.resolve("/tmp/shared-home"));
+    assert.equal(env.OPENCLAW_CONFIG_PATH, path.join(path.resolve("/tmp/shared-home"), "openclaw.json"));
+    assert.equal(env.OPENCLAW_PROFILE, undefined);
+    assert.equal(env.KEEP_ME, "yes");
+    delete globalThis.__ocbPath;
+});
+
+test("loadTeacherSurfaceFromInput returns a cached teacher surface without reopening the snapshot", () => {
+    const sentinel = { sourceKind: "watch_snapshot" };
+    globalThis.__teacherSurfaceSentinel = sentinel;
+    const loadTeacherSurfaceFromInput = loadFunctionFromSourcePath({
+        sourcePath: path.join(__dirname, "..", "src", "index.js"),
+        startMarker: "function loadTeacherSurfaceFromInput",
+        endMarker: "function summarizeTeacherLoopWatchState",
+        prelude: `
+            function resolveOperatorTeacherSnapshotPath() {
+                throw new Error("should not resolve teacher snapshot path when a cached surface is present");
+            }
+            function normalizeOptionalString(value) {
+                return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+            }
+            function loadTeacherSurface() {
+                throw new Error("should not load teacher surface when a cached surface is present");
+            }
+        `
+    });
+    assert.equal(loadTeacherSurfaceFromInput({ __loadedTeacherSurface: sentinel }), sentinel);
+    delete globalThis.__teacherSurfaceSentinel;
+});
+
+test("loadOperatorEventExport returns a cached event export without rescanning roots", () => {
+    const cachedExport = { sourceKind: "bundle_root", normalizedEventExport: { feedbackEvents: [] } };
+    const loadOperatorEventExport = loadFunctionFromSourcePath({
+        sourcePath: path.join(__dirname, "..", "src", "index.js"),
+        startMarker: "function loadOperatorEventExport",
+        endMarker: "function summarizePrincipalItem",
+        prelude: `
+            const path = globalThis.__ocbPath;
+            function normalizeOptionalString(value) {
+                return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+            }
+            function loadOperatorEventExportFromPath() {
+                throw new Error("should not load an explicit event export path when a cached export is present");
+            }
+            function loadLatestOperatorEventExportFromScanRoots() {
+                throw new Error("should not scan event export roots when a cached export is present");
+            }
+            function resolveOperatorEventExportScanRoots() {
+                throw new Error("should not resolve scan roots when a cached export is present");
+            }
+        `
+    });
+    assert.equal(loadOperatorEventExport({ __loadedOperatorEventExport: cachedExport }), cachedExport);
+});
+
+test("buildAttachStatusCompileInput suppresses serve-time route logging for status probes", () => {
+    const buildAttachStatusCompileInput = loadFunctionFromSourcePath({
+        sourcePath: path.join(__dirname, "..", "src", "index.js"),
+        startMarker: "function buildAttachStatusCompileInput",
+        endMarker: "export function describeAttachStatus",
+        prelude: `
+            const DEFAULT_AGENT_ID = "openclaw-runtime";
+            const DEFAULT_ATTACH_STATUS_MESSAGE = "openclaw attach status probe";
+            const DEFAULT_ATTACH_STATUS_RUNTIME_HINTS = ["attach", "status", "probe"];
+            function normalizeOptionalString(value) {
+                return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+            }
+        `
+    });
+    const compileInput = buildAttachStatusCompileInput("/tmp/activation", undefined);
+    assert.equal(compileInput._suppressServeLog, true);
+    assert.deepEqual(compileInput.runtimeHints, ["attach", "status", "probe"]);
+});
+
+test("summarizeActivePackObservability forwards the shared pack cache", () => {
+    globalThis.__sharedPackCache = new Map();
+    const summarizeActivePackObservability = loadFunctionFromSourcePath({
+        sourcePath: path.join(__dirname, "..", "src", "index.js"),
+        startMarker: "function summarizeActivePackObservability",
+        endMarker: "function summarizeLastPromotion",
+        prelude: `
+            function buildMissingLabelFlowSummary(detail) { return { detail }; }
+            function buildMissingLearningPathSummary(detail) { return { detail }; }
+            function summarizePackObservability() { return { labelFlow: { detail: "ok" }, learningPath: { detail: "ok" } }; }
+            function toErrorMessage(error) { return error instanceof Error ? error.message : String(error); }
+            function loadPackFromActivation(rootDir, slot, options = {}) {
+                globalThis.__lastPackCache = options.packCache;
+                return { manifest: {}, graph: {}, router: {} };
+            }
+        `
+    });
+    summarizeActivePackObservability("/tmp/activation", { packId: "pack-1", activationReady: true }, { packCache: globalThis.__sharedPackCache });
+    assert.equal(globalThis.__lastPackCache, globalThis.__sharedPackCache);
+    delete globalThis.__sharedPackCache;
+    delete globalThis.__lastPackCache;
+});
+
+test("describeActivationObservability reuses caller inspection and does not reload the selected active pack twice", () => {
+    const sourcePath = path.join(__dirname, "..", "..", "..", "pack-format", "vendor", "index.js");
+    const describeActivationObservability = loadFunctionFromSourcePath({
+        sourcePath,
+        startMarker: "export function describeActivationObservability",
+        endMarker: "export function activatePack",
+        prelude: `
+            let inspectCalls = 0;
+            const loadCalls = [];
+            globalThis.__inspectCalls = () => inspectCalls;
+            globalThis.__loadCalls = () => loadCalls.slice();
+            function inspectActivationState() {
+                inspectCalls += 1;
+                return globalThis.__inspection;
+            }
+            function buildCompileTargetFromInspection(inspection) {
+                return inspection === null ? null : {
+                    packId: inspection.packId,
+                    builtAt: inspection.packId,
+                    eventRange: { start: 0, end: 0, count: 0 }
+                };
+            }
+            function loadPackFromActivation(rootDir, slot, options = {}) {
+                loadCalls.push({ slot, packCache: options.packCache });
+                return {
+                    manifest: { routeArtifact: { slot } },
+                    router: null,
+                    graph: {}
+                };
+            }
+            function buildServedArtifactProof() { return { served: true }; }
+            function describeLearnedRouteFnFreshness() { return { available: true }; }
+            function describeRouteArtifactDiff() { return { changed: false }; }
+            function describeGraphDynamicsFreshness() { return { runtimePlasticitySource: "pack" }; }
+            function describeGraphEvolutionLog() { return { structuralEvolutionSummary: { changed: false, operationsApplied: [], liveBlockCount: 0, prunedBlockCount: 0, prePruneBlockCount: 0, operatorSummary: "ok" }, connectDiagnostics: null, structuralOps: {}, blockCount: 0, strongestBlockId: null }; }
+            function emptyInitHandoff() { return { handoffState: "missing", initMode: null, seedStateVisible: false, seedBlockCount: 0 }; }
+            function describePackInitHandoff() { return { handoffState: "pg_promoted_pack_authoritative", initMode: "fast_boot_defaults", seedStateVisible: false, seedBlockCount: 0 }; }
+            function promotionFreshnessDelta() { return null; }
+            function isStrictlyFresherTarget() { return false; }
+        `
+    });
+    globalThis.__inspection = {
+        active: { packId: "pack-active" },
+        candidate: { packId: "pack-candidate" },
+        previous: null,
+        pointers: {
+            active: { updatedAt: "2026-04-19T00:00:00.000Z" },
+            candidate: { updatedAt: "2026-04-19T00:00:01.000Z" },
+            previous: null
+        },
+        promotion: { allowed: true, findings: [] },
+        rollback: { allowed: false, findings: [] }
+    };
+    const packCache = new Map();
+    describeActivationObservability("/tmp/activation", "active", {
+        inspection: globalThis.__inspection,
+        packCache
+    });
+    assert.equal(globalThis.__inspectCalls(), 0);
+    assert.deepEqual(globalThis.__loadCalls().map((entry) => entry.slot), ["active", "candidate"]);
+    assert.ok(globalThis.__loadCalls().every((entry) => entry.packCache === packCache));
+    delete globalThis.__inspection;
+    delete globalThis.__inspectCalls;
+    delete globalThis.__loadCalls;
+});
+
+test("resolveActivationCompileTarget accepts a preloaded pack without reopening activation payloads", () => {
+    const resolveActivationCompileTarget = loadFunctionFromSourcePath({
+        sourcePath: path.join(__dirname, "..", "..", "..", "compiler", "vendor", "index.js"),
+        startMarker: "export function resolveActivationCompileTarget",
+        endMarker: "export function loadPackForActivationCompile",
+        prelude: `
+            function loadPackFromActivation() {
+                throw new Error("should not reload activation payloads when pack is already supplied");
+            }
+            function describePackCompileTarget(pack) {
+                return { packId: pack.manifest.packId };
+            }
+            function resolveActivationCompileExpectation() { return undefined; }
+            function validateRuntimeCompileExpectation() { return []; }
+            function validateRuntimeCompileTargetExpectation() { return []; }
+            function assertActivationCompileSafety() {}
+        `
+    });
+    const pack = { manifest: { packId: "pack-active" } };
+    const target = { packId: "pack-active" };
+    const resolved = resolveActivationCompileTarget("/tmp/activation", { pack, target });
+    assert.equal(resolved.pack, pack);
+    assert.equal(resolved.target, target);
+    assert.equal(resolved.slot, "active");
+});

--- a/packages/compiler/vendor/index.js
+++ b/packages/compiler/vendor/index.js
@@ -1110,13 +1110,13 @@ function activationFreshnessNotes(rootDir, slot, target) {
 }
 export function resolveActivationCompileTarget(rootDir, options = {}) {
     const slot = options.slot ?? "active";
-    const pack = loadPackFromActivation(rootDir, slot, {
+    const pack = options.pack ?? loadPackFromActivation(rootDir, slot, {
         requireActivationReady: options.requireActivationReady !== false
     });
     if (pack === null) {
         throw new Error(`Activation slot ${slot} is empty`);
     }
-    const target = describePackCompileTarget(pack);
+    const target = options.target ?? describePackCompileTarget(pack);
     const expectation = resolveActivationCompileExpectation(options);
     if (expectation !== undefined) {
         const expectationErrors = validateRuntimeCompileExpectation(expectation);

--- a/packages/pack-format/vendor/index.js
+++ b/packages/pack-format/vendor/index.js
@@ -372,7 +372,7 @@ export function validatePackActivationReadiness(packOrRootDir) {
     let pack;
     if (typeof packOrRootDir === "string") {
         try {
-            pack = loadPack(packOrRootDir);
+            pack = loadPackManifestRecord(packOrRootDir);
         }
         catch (error) {
             return [error instanceof Error ? error.message : String(error)];
@@ -548,7 +548,11 @@ function assertRetainedPointerMatchesManifest(slot, record, options = {}) {
     }
 }
 function ensurePackRecordMatchesManifest(record, options = {}) {
-    const pack = loadPack(path.resolve(record.packRootDir));
+    const includePayloads = options.includePayloads !== false;
+    const pack = loadCachedPackRecord(path.resolve(record.packRootDir), {
+        includePayloads,
+        packCache: options.packCache
+    });
     const errors = [];
     if (path.resolve(pack.manifestPath) !== path.resolve(record.manifestPath)) {
         errors.push(`pointer manifestPath ${record.manifestPath} does not match pack manifest ${pack.manifestPath}`);
@@ -631,7 +635,7 @@ function buildLearningSpineActivationPackSnapshot(record) {
     let graphChecksum = null;
     let routerIdentity = record.routerIdentity;
     try {
-        const pack = loadPack(path.resolve(record.packRootDir));
+        const pack = loadPackManifestRecord(path.resolve(record.packRootDir));
         routerChecksum = pack.manifest.payloadChecksums.router;
         graphChecksum = pack.manifest.payloadChecksums.graph;
         routerIdentity = pack.router?.routerIdentity ?? record.routerIdentity;
@@ -688,8 +692,7 @@ function inspectPointerRecord(slot, record) {
     }
     const findings = [];
     try {
-        const pack = ensurePackRecordMatchesManifest(record, { requireActivationReady: true });
-        findings.push(...validatePackActivationReadiness(pack));
+        ensurePackRecordMatchesManifest(record, { requireActivationReady: true, includePayloads: false });
     }
     catch (error) {
         findings.push(error instanceof Error ? error.message : String(error));
@@ -741,7 +744,7 @@ function previewPromotionPointers(current, updatedAt) {
     let candidatePack = null;
     if (current.candidate !== null) {
         try {
-            candidatePack = ensurePackRecordMatchesManifest(current.candidate, { requireActivationReady: true });
+            candidatePack = ensurePackRecordMatchesManifest(current.candidate, { requireActivationReady: true, includePayloads: false });
         }
         catch (error) {
             findings.push(error instanceof Error ? error.message : String(error));
@@ -750,7 +753,7 @@ function previewPromotionPointers(current, updatedAt) {
     let activePack = null;
     if (current.active !== null) {
         try {
-            activePack = ensurePackRecordMatchesManifest(current.active, { requireActivationReady: true });
+            activePack = ensurePackRecordMatchesManifest(current.active, { requireActivationReady: true, includePayloads: false });
         }
         catch (error) {
             findings.push(error instanceof Error ? error.message : String(error));
@@ -798,7 +801,7 @@ function previewRollbackPointers(current, updatedAt) {
     let previousPack = null;
     if (current.previous !== null) {
         try {
-            previousPack = ensurePackRecordMatchesManifest(current.previous, { requireActivationReady: true });
+            previousPack = ensurePackRecordMatchesManifest(current.previous, { requireActivationReady: true, includePayloads: false });
         }
         catch (error) {
             findings.push(error instanceof Error ? error.message : String(error));
@@ -807,7 +810,7 @@ function previewRollbackPointers(current, updatedAt) {
     let activePack = null;
     if (current.active !== null) {
         try {
-            activePack = ensurePackRecordMatchesManifest(current.active, { requireActivationReady: true });
+            activePack = ensurePackRecordMatchesManifest(current.active, { requireActivationReady: true, includePayloads: false });
         }
         catch (error) {
             findings.push(error instanceof Error ? error.message : String(error));
@@ -863,7 +866,8 @@ export function loadPackFromActivation(rootDir, slot = "active", options = {}) {
         return null;
     }
     return ensurePackRecordMatchesManifest(record, {
-        requireActivationReady: options.requireActivationReady === true
+        requireActivationReady: options.requireActivationReady === true,
+        packCache: options.packCache
     });
 }
 export function describeActivationTarget(rootDir, slot = "active", options = {}) {
@@ -903,7 +907,8 @@ export function inspectActivationState(rootDir, updatedAt = "2026-03-06T00:00:00
     };
 }
 export function describeActivationObservability(rootDir, slot = "active", options = {}) {
-    const inspection = inspectActivationState(rootDir, options.updatedAt);
+    const inspection = options.inspection ?? inspectActivationState(rootDir, options.updatedAt);
+    const packCache = options.packCache instanceof Map ? options.packCache : new Map();
     const selectedInspection = slot === "active" ? inspection.active : slot === "candidate" ? inspection.candidate : inspection.previous;
     const target = selectedInspection === null ? null : buildCompileTargetFromInspection(selectedInspection);
     let pack = null;
@@ -911,27 +916,40 @@ export function describeActivationObservability(rootDir, slot = "active", option
     let candidatePack = null;
     try {
         pack = loadPackFromActivation(rootDir, slot, {
-            requireActivationReady: options.requireActivationReady === true
+            requireActivationReady: options.requireActivationReady === true,
+            packCache
         });
     }
     catch {
         pack = null;
     }
-    try {
-        activePack = loadPackFromActivation(rootDir, "active", {
-            requireActivationReady: options.requireActivationReady === true
-        });
+    if (slot === "active") {
+        activePack = pack;
     }
-    catch {
-        activePack = null;
+    else {
+        try {
+            activePack = loadPackFromActivation(rootDir, "active", {
+                requireActivationReady: options.requireActivationReady === true,
+                packCache
+            });
+        }
+        catch {
+            activePack = null;
+        }
     }
-    try {
-        candidatePack = loadPackFromActivation(rootDir, "candidate", {
-            requireActivationReady: options.requireActivationReady === true
-        });
+    if (slot === "candidate") {
+        candidatePack = pack;
     }
-    catch {
-        candidatePack = null;
+    else {
+        try {
+            candidatePack = loadPackFromActivation(rootDir, "candidate", {
+                requireActivationReady: options.requireActivationReady === true,
+                packCache
+            });
+        }
+        catch {
+            candidatePack = null;
+        }
     }
     const activeTarget = inspection.active === null ? null : buildCompileTargetFromInspection(inspection.active);
     const candidateTarget = inspection.candidate === null ? null : buildCompileTargetFromInspection(inspection.candidate);
@@ -1061,6 +1079,71 @@ export function rollbackActivePack(rootDir, updatedAtOrOptions = "2026-03-06T00:
     return result;
 }
 export { LEARNING_SPINE_LOG_LAYOUT, appendLearningSpineLogEntry, buildLearningSpineLogId, readLearningSpineLogEntries, resolveLearningSpineLogPath } from "./learning-spine-logs.js";
+function loadPackManifestRecord(rootDir) {
+    const resolvedRootDir = path.resolve(rootDir);
+    const manifestPath = path.join(resolvedRootDir, PACK_LAYOUT.manifest);
+    if (!existsSync(manifestPath)) {
+        throw new Error(`pack manifest not found: ${manifestPath}`);
+    }
+    const manifest = readJsonFile(manifestPath);
+    const manifestErrors = validatePackDescriptor(manifest);
+    if (manifestErrors.length > 0) {
+        throw new Error(`Invalid pack descriptor: ${manifestErrors.join("; ")}`);
+    }
+    const graphPath = resolvePackAssetPath(resolvedRootDir, manifest.runtimeAssets.graphPath, "graph payload");
+    const vectorPath = resolvePackAssetPath(resolvedRootDir, manifest.runtimeAssets.vectorPath, "vector payload");
+    const routerPath = manifest.runtimeAssets.router.artifactPath === null
+        ? null
+        : resolvePackAssetPath(resolvedRootDir, manifest.runtimeAssets.router.artifactPath, "router payload");
+    const fileErrors = [];
+    pushFileError(fileErrors, graphPath, "graph payload");
+    pushFileError(fileErrors, vectorPath, "vector payload");
+    if (routerPath !== null && manifest.runtimeAssets.router.kind !== "none") {
+        pushFileError(fileErrors, routerPath, "router payload");
+    }
+    if (fileErrors.length > 0) {
+        throw new Error(`Invalid pack descriptor: ${fileErrors.join("; ")}`);
+    }
+    const router = routerPath === null ? null : readJsonFile(routerPath);
+    const payloadErrors = router === null ? [] : validateRouterArtifact(router, manifest);
+    if (routerPath === null) {
+        if (manifest.payloadChecksums.router !== null) {
+            payloadErrors.push("router checksum must be null when router artifact is absent");
+        }
+    }
+    else {
+        const routerChecksum = sha256File(routerPath);
+        if (manifest.payloadChecksums.router !== routerChecksum) {
+            payloadErrors.push("router checksum does not match manifest");
+        }
+    }
+    if (payloadErrors.length > 0) {
+        throw new Error(`Invalid pack descriptor: ${payloadErrors.join("; ")}`);
+    }
+    return {
+        rootDir: resolvedRootDir,
+        manifestPath,
+        graphPath,
+        vectorPath,
+        routerPath,
+        manifest,
+        router
+    };
+}
+function loadCachedPackRecord(rootDir, options = {}) {
+    const resolvedRootDir = path.resolve(rootDir);
+    const includePayloads = options.includePayloads === true;
+    const packCache = options.packCache instanceof Map ? options.packCache : null;
+    const cached = packCache?.get(resolvedRootDir) ?? null;
+    if (cached !== null && cached !== undefined) {
+        if (!includePayloads || ("graph" in cached && "vectors" in cached)) {
+            return cached;
+        }
+    }
+    const loaded = includePayloads ? loadPack(resolvedRootDir) : loadPackManifestRecord(resolvedRootDir);
+    packCache?.set(resolvedRootDir, loaded);
+    return loaded;
+}
 export function loadPack(rootDir) {
     const manifestPath = path.join(rootDir, PACK_LAYOUT.manifest);
     if (!existsSync(manifestPath)) {


### PR DESCRIPTION
## Summary
- isolate the plugin-manager child env during converge so `--openclaw-home` does not drift into the current profile boundary
- reuse cached status inputs and active-pack loads so operator status/report stops reopening the same activation payloads
- suppress serve-time route logging during status probes and add focused regressions for the new cache + preloaded-pack paths

## Verification
- `node --check /Users/cormorantai/openclawbrain/packages/compiler/vendor/index.js`
- `node --check /Users/cormorantai/openclawbrain/packages/pack-format/vendor/index.js`
- `node --check /Users/cormorantai/openclawbrain/packages/cli/dist/src/index.js`
- `node --check /Users/cormorantai/openclawbrain/packages/cli/dist/src/cli.js`
- `node --test /Users/cormorantai/openclawbrain/packages/cli/dist/test/operator-status-regressions.test.js /Users/cormorantai/openclawbrain/packages/cli/dist/test/status-single-snapshot.test.js /Users/cormorantai/openclawbrain/packages/cli/dist/test/install-converge.test.js`
- live read-count probe against the installed CLI after hotfixing this machine:
  - active pack `vectors.json` reads during `describeCurrentProfileBrainStatusWithReport(...)` dropped from 12 to 4
  - teacher snapshot reads stayed at 1
