### PR TITLE
Keep summary status detail selection internal

### DIFF
--- a/packages/cli/dist/src/cli.js
+++ b/packages/cli/dist/src/cli.js
@@ -35,6 +35,7 @@ const OPENCLAWBRAIN_EMBEDDER_BASE_URL_ENV = "OPENCLAWBRAIN_EMBEDDER_BASE_URL";
 const OPENCLAWBRAIN_EMBEDDER_PROVIDER_ENV = "OPENCLAWBRAIN_EMBEDDER_PROVIDER";
 const OPENCLAWBRAIN_EMBEDDER_MODEL_ENV = "OPENCLAWBRAIN_EMBEDDER_MODEL";
 const OPENCLAWBRAIN_INSTALL_SKIP_EMBEDDER_PROVISION_ENV = "OPENCLAWBRAIN_INSTALL_SKIP_EMBEDDER_PROVISION";
+const OPERATOR_SURFACE_DETAIL_LEVEL = Symbol.for("@openclawbrain/cli/operatorSurfaceDetailLevel");
 const LEGACY_COMPAT_PACKAGE_NAME = "@jonathangu/openclawbrain";
 const INSTALL_COMPATIBLE_LOCAL_TEACHER_MODEL_PREFIXES = [
     "gemma4:31b",
@@ -1673,6 +1674,15 @@ function formatCurrentProfileStatusSummary(status, report, targetInspection, opt
         `logs        root=${status.brain.logRoot ?? "none"}`,
         `turn        attribution=${status.currentTurnAttribution === null ? "none" : status.currentTurnAttribution.contract}`
     ].join("\n");
+}
+function withOperatorSurfaceReportDetailLevel(input, detailLevel) {
+    const taggedInput = { ...input };
+    Object.defineProperty(taggedInput, OPERATOR_SURFACE_DETAIL_LEVEL, {
+        value: detailLevel,
+        enumerable: false,
+        configurable: true
+    });
+    return taggedInput;
 }
 // Auto-detection of activation root is now handled by the shared
 // resolveActivationRoot() helper in resolve-activation-root.ts.
@@ -7543,7 +7553,9 @@ export function runOperatorCli(argv = process.argv.slice(2)) {
         }, null, 2));
     }
     else {
-        const statusWithReport = describeCurrentProfileBrainStatusWithReport(operatorInput);
+        const statusWithReport = statusOrRollback.detailed
+            ? describeCurrentProfileBrainStatusWithReport(operatorInput)
+            : describeCurrentProfileBrainStatusWithReport(withOperatorSurfaceReportDetailLevel(operatorInput, "summary"));
         const normalizedStatusAndReport = applyAttachmentPolicyTruth(statusWithReport.status, statusWithReport.report);
         const report = normalizedStatusAndReport.report;
         const providerConfig = readOpenClawBrainProviderConfigFromSources({

--- a/packages/cli/dist/src/index.js
+++ b/packages/cli/dist/src/index.js
@@ -25,6 +25,9 @@ const RUNTIME_EVENT_EXPORT_BUNDLE_CONTRACT = "normalized_event_export_bundle.v1"
 const DEFAULT_ATTACH_STATUS_MESSAGE = "openclaw attach status probe";
 const DEFAULT_ATTACH_STATUS_RUNTIME_HINTS = ["attach", "status", "probe"];
 const BRAIN_SERVE_HOT_PATH_TIMING_DETAIL = "Measured inside compileRuntimeContext before serve-route logging; includes serve-path normalization, active-pack lookup, structural-budget resolution, route/candidate selection, and prompt assembly when run; excludes background scanner/embedder/teacher work, promotion, and runtime event-export writes.";
+// Internal-only signal so the CLI can request summary-friendly status reports
+// without widening the declared operator report API.
+const OPERATOR_SURFACE_DETAIL_LEVEL = Symbol.for("@openclawbrain/cli/operatorSurfaceDetailLevel");
 export const RUNTIME_EVENT_EXPORT_BUNDLE_LAYOUT = {
     manifest: "manifest.json",
     payload: "normalized-event-export.json"
@@ -6734,6 +6737,29 @@ function summarizePrincipalObservability(input, active) {
                 : `${pendingEvents.length} principal item(s) are newer than the active serving range`
     };
 }
+function buildSummaryOnlyPrincipalObservability(active) {
+    const detail = "summary status skipped principal feedback frontier inspection; rerun `openclawbrain status --detailed` when you need principal lag proof";
+    return {
+        available: false,
+        sourcePath: null,
+        sourceKind: "missing",
+        latestFeedback: null,
+        latestCorrection: null,
+        pendingCount: null,
+        pendingItems: [],
+        latestPromotion: {
+            known: false,
+            at: null,
+            activePackId: active?.packId ?? null,
+            activeEventRangeEnd: active?.eventRange.end ?? null,
+            includesLatestFeedback: null,
+            includesLatestCorrection: null,
+            note: detail
+        },
+        servingDownstreamOfLatestCorrection: null,
+        detail
+    };
+}
 function summarizeSupervision(input) {
     const loaded = loadOperatorEventExport(input);
     if (loaded === null) {
@@ -8052,6 +8078,12 @@ function buildCurrentProfileBrainStatusFromReport(report, policyMode, profileId)
     };
 }
 export function buildOperatorSurfaceReport(input) {
+    return buildOperatorSurfaceReportWithDetailLevel(input, resolveOperatorSurfaceReportDetailLevel(input));
+}
+function resolveOperatorSurfaceReportDetailLevel(input) {
+    return input?.[OPERATOR_SURFACE_DETAIL_LEVEL] === "summary" ? "summary" : "full";
+}
+function buildOperatorSurfaceReportWithDetailLevel(input, detailLevel) {
     const activationRoot = path.resolve(normalizeNonEmptyString(input.activationRoot, "activationRoot"));
     const updatedAt = normalizeIsoTimestamp(input.updatedAt, "updatedAt", new Date().toISOString());
     const brainAttachmentPolicy = normalizeBrainAttachmentPolicy(input.brainAttachmentPolicy);
@@ -8096,12 +8128,17 @@ export function buildOperatorSurfaceReport(input) {
         previous,
         inspectionError
     });
-    const activeObservability = inspectionError === null
-        ? summarizeActivePackObservability(activationRoot, active, { packCache })
-        : {
-            labelFlow: buildMissingLabelFlowSummary(`activation observability is unavailable: ${inspectionError}`),
-            learningPath: buildMissingLearningPathSummary(`activation observability is unavailable: ${inspectionError}`)
-        };
+    const activeObservability = detailLevel === "summary"
+        ? {
+            labelFlow: buildMissingLabelFlowSummary("summary status skipped active-pack label-flow inspection; rerun `openclawbrain status --detailed` for the full label-flow surface"),
+            learningPath: buildMissingLearningPathSummary("summary status skipped active-pack learning-path inspection; rerun `openclawbrain status --detailed` for the full learning-path surface")
+        }
+        : inspectionError === null
+            ? summarizeActivePackObservability(activationRoot, active, { packCache })
+            : {
+                labelFlow: buildMissingLabelFlowSummary(`activation observability is unavailable: ${inspectionError}`),
+                learningPath: buildMissingLearningPathSummary(`activation observability is unavailable: ${inspectionError}`)
+            };
     const servePath = probeOperatorServePath(activationRoot, observability, active?.packId ?? null);
     const learnedRouting = observability === null
         ? summarizeLearnedRoutingWithoutObservability(active)
@@ -8187,7 +8224,9 @@ export function buildOperatorSurfaceReport(input) {
         routeFn,
         hook,
         attachmentTruth,
-        principal: summarizePrincipalObservability(cachedInput, active),
+        principal: detailLevel === "summary"
+            ? buildSummaryOnlyPrincipalObservability(active)
+            : summarizePrincipalObservability(cachedInput, active),
         manyProfile: summarizeManyProfileSupport(brainAttachmentPolicy)
     };
     const findings = buildOperatorFindings(reportBase);
@@ -8204,8 +8243,17 @@ export function describeCurrentProfileBrainStatusWithReport(input) {
         status: buildCurrentProfileBrainStatusFromReport(report, report.manyProfile.declaredAttachmentPolicy, normalizeOptionalString(input.profileId) ?? null)
     };
 }
+function withOperatorSurfaceReportDetailLevel(input, detailLevel) {
+    const taggedInput = { ...input };
+    Object.defineProperty(taggedInput, OPERATOR_SURFACE_DETAIL_LEVEL, {
+        value: detailLevel,
+        enumerable: false,
+        configurable: true
+    });
+    return taggedInput;
+}
 export function describeCurrentProfileBrainStatus(input) {
-    return describeCurrentProfileBrainStatusWithReport(input).status;
+    return describeCurrentProfileBrainStatusWithReport(withOperatorSurfaceReportDetailLevel(input, "summary")).status;
 }
 export function formatOperatorRollbackReport(result) {
     const header = result.allowed ? (result.dryRun ? "ROLLBACK ready" : "ROLLBACK ok") : "ROLLBACK blocked";

--- a/packages/cli/dist/test/status-single-snapshot.test.js
+++ b/packages/cli/dist/test/status-single-snapshot.test.js
@@ -66,6 +66,607 @@ test("current profile status with report reuses one live operator snapshot", () 
     delete globalThis.__ocbBuildCalls;
 });
 
+test("current profile status without report uses the internal summary detail marker", () => {
+    const describeCurrentProfileBrainStatus = loadFunction({
+        file: "index.js",
+        startMarker: "export function describeCurrentProfileBrainStatus(input)",
+        endMarker: "export function formatOperatorRollbackReport",
+        prelude: `
+            const OPERATOR_SURFACE_DETAIL_LEVEL = Symbol.for("@openclawbrain/cli/operatorSurfaceDetailLevel");
+            function withOperatorSurfaceReportDetailLevel(input, detailLevel) {
+                const taggedInput = { ...input };
+                Object.defineProperty(taggedInput, OPERATOR_SURFACE_DETAIL_LEVEL, {
+                    value: detailLevel,
+                    enumerable: false,
+                    configurable: true
+                });
+                return taggedInput;
+            }
+            let seenInput = null;
+            function describeCurrentProfileBrainStatusWithReport(input) {
+                seenInput = input;
+                return {
+                    status: {
+                        marker: "summary",
+                        input
+                    }
+                };
+            }
+            globalThis.__ocbSummaryInput = () => seenInput;
+            globalThis.__ocbSummaryDetailKey = OPERATOR_SURFACE_DETAIL_LEVEL;
+        `
+    });
+
+    const input = {
+        activationRoot: "/tmp/activation"
+    };
+    const result = describeCurrentProfileBrainStatus(input);
+    const summaryInput = globalThis.__ocbSummaryInput();
+    const detailKey = globalThis.__ocbSummaryDetailKey;
+
+    assert.equal(result.marker, "summary");
+    assert.equal(result.input.activationRoot, "/tmp/activation");
+    assert.equal(input[detailKey], undefined);
+    assert.equal(summaryInput.activationRoot, "/tmp/activation");
+    assert.equal(summaryInput[detailKey], "summary");
+    assert.deepEqual(Object.keys(summaryInput), ["activationRoot"]);
+    assert.notEqual(summaryInput, input);
+
+    delete globalThis.__ocbSummaryInput;
+    delete globalThis.__ocbSummaryDetailKey;
+});
+
+test("summary operator status report skips detailed-only active-pack and principal surfaces", () => {
+    const buildOperatorSurfaceReport = loadFunction({
+        file: "index.js",
+        startMarker: "export function buildOperatorSurfaceReport",
+        endMarker: "export function describeCurrentProfileBrainStatusWithReport",
+        prelude: `
+            const OPERATOR_SURFACE_DETAIL_LEVEL = Symbol.for("@openclawbrain/cli/operatorSurfaceDetailLevel");
+            const path = {
+                resolve(value) {
+                    return value;
+                }
+            };
+            function normalizeNonEmptyString(value) {
+                return value;
+            }
+            function normalizeIsoTimestamp(value, _fieldName, fallbackValue) {
+                return value ?? fallbackValue;
+            }
+            function normalizeBrainAttachmentPolicy(value) {
+                return value ?? "dedicated";
+            }
+            function normalizeOptionalString(value) {
+                return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+            }
+            function resolveOperatorTeacherSnapshotPath() {
+                return null;
+            }
+            function loadTeacherSurface() {
+                return null;
+            }
+            function loadOperatorEventExport() {
+                return null;
+            }
+            function inspectActivationState() {
+                return {
+                    active: {
+                        slot: "active",
+                        packId: "pack-1",
+                        activationReady: true,
+                        routePolicy: "optional",
+                        routerIdentity: "pack-1:route_fn",
+                        workspaceSnapshot: null,
+                        workspaceRevision: null,
+                        eventRange: { count: 0, end: null },
+                        eventExportDigest: null,
+                        builtAt: "2026-04-04T14:00:00.000Z",
+                        findings: []
+                    },
+                    candidate: null,
+                    previous: null,
+                    pointers: {
+                        active: { updatedAt: "2026-04-04T14:00:00.000Z" },
+                        candidate: null,
+                        previous: null
+                    },
+                    promotion: {
+                        allowed: false,
+                        findings: []
+                    },
+                    rollback: {
+                        allowed: false,
+                        findings: []
+                    }
+                };
+            }
+            function summarizeOperatorSlot(slot, updatedAt) {
+                return {
+                    ...slot,
+                    updatedAt
+                };
+            }
+            function describeActivationObservability() {
+                return {
+                    promotionFreshness: {
+                        candidateAheadBy: null
+                    },
+                    initHandoff: {
+                        handoffState: "seed_state_authoritative",
+                        initMode: "fast_boot_defaults",
+                        seedStateVisible: true
+                    },
+                    learnedRouteFn: {
+                        required: false,
+                        available: false,
+                        routerIdentity: "pack-1:route_fn",
+                        routeFnVersion: null,
+                        trainingMethod: null,
+                        routerTrainedAt: null,
+                        objective: null,
+                        pgProfile: null,
+                        routerChecksum: null,
+                        objectiveChecksum: null,
+                        updateMechanism: null,
+                        updateVersion: null,
+                        updateCount: null,
+                        supervisionCount: null,
+                        collectedLabels: null,
+                        freshnessChecksum: null
+                    },
+                    graphEvolutionLog: null,
+                    graphDynamics: {
+                        runtimePlasticitySource: "teacher_snapshot"
+                    }
+                };
+            }
+            function toErrorMessage(error) {
+                return error instanceof Error ? error.message : String(error);
+            }
+            function summarizeOperatorActivationState() {
+                return {
+                    state: "healthy_seed",
+                    detail: "ok"
+                };
+            }
+            let activePackObservabilityCalls = 0;
+            function buildMissingLabelFlowSummary(detail) {
+                return {
+                    source: "missing",
+                    detail
+                };
+            }
+            function buildMissingLearningPathSummary(detail) {
+                return {
+                    available: false,
+                    source: "missing",
+                    detail
+                };
+            }
+            function buildSummaryOnlyPrincipalObservability(active) {
+                return {
+                    available: false,
+                    sourcePath: null,
+                    sourceKind: "missing",
+                    latestFeedback: null,
+                    latestCorrection: null,
+                    pendingCount: null,
+                    pendingItems: [],
+                    latestPromotion: {
+                        known: false,
+                        at: null,
+                        activePackId: active?.packId ?? null,
+                        activeEventRangeEnd: active?.eventRange.end ?? null,
+                        includesLatestFeedback: null,
+                        includesLatestCorrection: null,
+                        note: "summary-only principal surface"
+                    },
+                    servingDownstreamOfLatestCorrection: null,
+                    detail: "summary-only principal surface"
+                };
+            }
+            function summarizeActivePackObservability() {
+                activePackObservabilityCalls += 1;
+                return {
+                    labelFlow: {
+                        source: "active_pack",
+                        detail: "active-pack label flow"
+                    },
+                    learningPath: {
+                        available: true,
+                        source: "active_pack",
+                        detail: "active-pack learning path"
+                    }
+                };
+            }
+            function probeOperatorServePath() {
+                return {
+                    state: "serving_active_pack",
+                    fallbackToStaticContext: false,
+                    hardRequirementViolated: false,
+                    activePackId: "pack-1",
+                    usedLearnedRouteFn: false,
+                    routerIdentity: "pack-1:route_fn",
+                    selectionMode: null,
+                    selectionDigest: null,
+                    requestedBudgetStrategy: null,
+                    resolvedBudgetStrategy: null,
+                    resolvedMaxContextBlocks: null,
+                    structuralBudgetSource: null,
+                    structuralBudgetEvidence: null,
+                    structuralBudgetPressures: null,
+                    contextAttribution: {
+                        selectedContextCount: 0,
+                        stableKernelBlockCount: 0,
+                        brainCompiledBlockCount: 0,
+                        stableKernelSources: [],
+                        brainCompiledSources: [],
+                        selectionTiers: null,
+                        evidence: "stable_kernel_only",
+                        detail: "kernel only"
+                    },
+                    structuralDecision: {
+                        origin: "static",
+                        basis: "none",
+                        detail: "static"
+                    },
+                    timing: {
+                        totalMs: null,
+                        routeSelectionMs: null,
+                        promptAssemblyMs: null,
+                        otherMs: null,
+                        backgroundWorkIncluded: false
+                    },
+                    error: null,
+                    refreshStatus: "updated",
+                    freshnessChecksum: null
+                };
+            }
+            function summarizeLearnedRoutingWithoutObservability(active) {
+                return {
+                    required: false,
+                    available: false,
+                    routerIdentity: active?.routerIdentity ?? null,
+                    routeFnVersion: null,
+                    trainingMethod: null,
+                    routerTrainedAt: null,
+                    objective: null,
+                    pgProfile: null,
+                    routerChecksum: null,
+                    objectiveChecksum: null,
+                    updateMechanism: null,
+                    updateVersion: null,
+                    updateCount: null,
+                    supervisionCount: null,
+                    collectedLabelsTotal: null,
+                    freshnessChecksum: null,
+                    handoffState: "seed_state_authoritative",
+                    initMode: "fast_boot_defaults",
+                    seedStateVisible: true
+                };
+            }
+            function summarizeRouteFnFreshness() {
+                return {
+                    available: false,
+                    trainedAt: null,
+                    updatedAt: null,
+                    usedAt: null,
+                    fallbackReason: null,
+                    detail: "route_fn not visible"
+                };
+            }
+            function summarizeTeacherLoop() {
+                return {
+                    available: false,
+                    sourcePath: null,
+                    sourceKind: "missing",
+                    snapshotUpdatedAt: null,
+                    lastRunAt: null,
+                    lastNoOpReason: "unavailable",
+                    latestFreshness: "unavailable",
+                    startedAt: null,
+                    lastHeartbeatAt: null,
+                    lastScanAt: null,
+                    pollIntervalSeconds: null,
+                    watchState: "not_visible",
+                    watch: null,
+                    lastProcessedAt: null,
+                    artifactCount: null,
+                    queueDepth: null,
+                    queueCapacity: null,
+                    running: null,
+                    replayedBundleCount: null,
+                    replayedEventCount: null,
+                    exportedBundleCount: null,
+                    exportedEventCount: null,
+                    sessionTailSessionsTracked: null,
+                    sessionTailBridgedEventCount: null,
+                    localSessionTailNoopReason: null,
+                    learningCadence: "unavailable",
+                    scanPolicy: "unavailable",
+                    liveSlicesPerCycle: null,
+                    backfillSlicesPerCycle: null,
+                    failureMode: "unavailable",
+                    failureDetail: null,
+                    lastAppliedMaterializationJobId: null,
+                    lastMaterializedPackId: null,
+                    observationBinding: {},
+                    lastObservedDelta: {
+                        explanation: "none"
+                    },
+                    notes: [],
+                    detail: "teacher snapshot unavailable"
+                };
+            }
+            function summarizeOperatorHook() {
+                return {
+                    scope: "exact_openclaw_home",
+                    openclawHome: null,
+                    extensionDir: null,
+                    hookPath: null,
+                    runtimeGuardPath: null,
+                    manifestPath: null,
+                    packageJsonPath: null,
+                    manifestId: null,
+                    installId: null,
+                    packageName: null,
+                    packageVersion: null,
+                    installLayout: null,
+                    additionalInstallCount: 0,
+                    installState: "installed",
+                    loadability: "loadable",
+                    loadProof: "status_probe_ready",
+                    guardSeverity: "none",
+                    guardActionability: "none",
+                    guardSummary: "ok",
+                    guardAction: "none",
+                    desynced: false,
+                    detail: "ok"
+                };
+            }
+            function summarizeOperatorAttachmentTruth() {
+                return {
+                    state: "attached",
+                    activationRoot: "/tmp/activation",
+                    servingSlot: "active",
+                    proofState: "self_proving",
+                    watchOnly: false,
+                    detail: "attached"
+                };
+            }
+            function summarizeBrainState(active) {
+                return {
+                    state: "seed_state_authoritative",
+                    initMode: "fast_boot_defaults",
+                    runtimePlasticitySource: "teacher_snapshot",
+                    seedStateVisible: true,
+                    seedBlockCount: 1,
+                    activePackId: active.packId,
+                    activeWorkspaceSnapshot: null,
+                    activeEventExportDigest: null,
+                    detail: "brain"
+                };
+            }
+            function summarizeBrainStateWithoutObservability(active, activation) {
+                return {
+                    state: active === null ? "no_active_pack" : "missing",
+                    initMode: null,
+                    runtimePlasticitySource: null,
+                    seedStateVisible: false,
+                    seedBlockCount: 0,
+                    activePackId: active?.packId ?? null,
+                    activeWorkspaceSnapshot: null,
+                    activeEventExportDigest: null,
+                    detail: activation.detail
+                };
+            }
+            function summarizeGraphObservability() {
+                return {
+                    available: true,
+                    runtimePlasticitySource: "teacher_snapshot",
+                    structuralOps: null,
+                    connectDiagnostics: null,
+                    changed: false,
+                    blockCount: 7,
+                    operationsApplied: [],
+                    liveBlockCount: 7,
+                    prunedBlockCount: 0,
+                    prePruneBlockCount: 7,
+                    strongestBlockId: "block-1",
+                    operatorSummary: "stable",
+                    latestMaterialization: {
+                        known: true,
+                        packId: "pack-1",
+                        changed: false,
+                        connectDiagnostics: null,
+                        operatorSummary: "stable",
+                        detail: "latest"
+                    },
+                    detail: "graph"
+                };
+            }
+            function summarizeGraphWithoutObservability() {
+                return {
+                    available: false,
+                    runtimePlasticitySource: null,
+                    structuralOps: null,
+                    connectDiagnostics: null,
+                    changed: null,
+                    blockCount: null,
+                    operationsApplied: [],
+                    liveBlockCount: null,
+                    prunedBlockCount: null,
+                    prePruneBlockCount: null,
+                    strongestBlockId: null,
+                    operatorSummary: null,
+                    latestMaterialization: {
+                        known: false,
+                        packId: null,
+                        changed: null,
+                        connectDiagnostics: null,
+                        operatorSummary: null,
+                        detail: "none"
+                    },
+                    detail: "graph"
+                };
+            }
+            function summarizeLastPromotion() {
+                return {
+                    known: true,
+                    at: "2026-04-04T14:00:00.000Z",
+                    note: "promoted"
+                };
+            }
+            function summarizeCandidateAheadBy() {
+                return [];
+            }
+            function summarizeSupervision() {
+                return {
+                    available: false,
+                    sourcePath: null,
+                    sourceKind: "missing",
+                    exportDigest: null,
+                    exportedAt: null,
+                    flowing: null,
+                    scanPolicy: null,
+                    scanSurfaceCount: 0,
+                    scanSurfaces: [],
+                    sourceCount: 0,
+                    freshestSourceStream: null,
+                    freshestCreatedAt: null,
+                    freshestKind: null,
+                    humanLabelCount: null,
+                    selfLabelCount: null,
+                    attributedEventCount: null,
+                    totalEventCount: null,
+                    selectionDigestCount: null,
+                    sources: [],
+                    detail: "no event export"
+                };
+            }
+            function summarizeAlwaysOnLearning() {
+                return {
+                    available: false,
+                    sourcePath: null,
+                    bootstrapped: null,
+                    mode: "unavailable",
+                    nextPriorityLane: "unavailable",
+                    nextPriorityBucket: "unavailable",
+                    backlogState: "unavailable",
+                    pendingLive: null,
+                    pendingBackfill: null,
+                    pendingTotal: null,
+                    pendingByBucket: null,
+                    freshLivePriority: null,
+                    principalCheckpointCount: null,
+                    pendingPrincipalCount: null,
+                    oldestUnlearnedPrincipalEvent: null,
+                    newestPendingPrincipalEvent: null,
+                    leadingPrincipalCheckpoint: null,
+                    principalCheckpoints: [],
+                    principalLagToPromotion: {
+                        activeEventRangeEnd: null,
+                        latestPrincipalSequence: null,
+                        sequenceLag: null,
+                        status: "unavailable"
+                    },
+                    warningStates: ["teacher_snapshot_unavailable"],
+                    learnedRange: null,
+                    materializationCount: null,
+                    lastMaterializedAt: null,
+                    lastMaterializationReason: null,
+                    lastMaterializationLane: null,
+                    lastMaterializationPriority: null,
+                    lastMaterializedPackId: null,
+                    detail: "missing"
+                };
+            }
+            let principalObservabilityCalls = 0;
+            function summarizePrincipalObservability() {
+                principalObservabilityCalls += 1;
+                return {
+                    available: true,
+                    sourcePath: "/tmp/export",
+                    sourceKind: "bundle_root",
+                    latestFeedback: null,
+                    latestCorrection: null,
+                    pendingCount: 0,
+                    pendingItems: [],
+                    latestPromotion: {
+                        known: false,
+                        at: null,
+                        activePackId: "pack-1",
+                        activeEventRangeEnd: null,
+                        includesLatestFeedback: null,
+                        includesLatestCorrection: null,
+                        note: "principal"
+                    },
+                    servingDownstreamOfLatestCorrection: null,
+                    detail: "principal"
+                };
+            }
+            function summarizeManyProfileSupport(policyMode) {
+                return {
+                    declaredAttachmentPolicy: policyMode
+                };
+            }
+            function buildOperatorFindings() {
+                return [];
+            }
+            function summarizeOperatorStatus() {
+                return "ok";
+            }
+            globalThis.__statusSummaryCounters = {
+                get() {
+                    return {
+                        activePackObservabilityCalls,
+                        principalObservabilityCalls
+                    };
+                },
+                reset() {
+                    activePackObservabilityCalls = 0;
+                    principalObservabilityCalls = 0;
+                }
+            };
+        `
+    });
+
+    globalThis.__statusSummaryCounters.reset();
+    const summaryInput = {
+        activationRoot: "/tmp/activation"
+    };
+    Object.defineProperty(summaryInput, Symbol.for("@openclawbrain/cli/operatorSurfaceDetailLevel"), {
+        value: "summary",
+        enumerable: false,
+        configurable: true
+    });
+    const summaryReport = buildOperatorSurfaceReport(summaryInput);
+
+    assert.deepEqual(globalThis.__statusSummaryCounters.get(), {
+        activePackObservabilityCalls: 0,
+        principalObservabilityCalls: 0
+    });
+    assert.equal(summaryReport.labelFlow.source, "missing");
+    assert.equal(summaryReport.learningPath.available, false);
+    assert.equal(summaryReport.principal.available, false);
+
+    globalThis.__statusSummaryCounters.reset();
+    const detailedReport = buildOperatorSurfaceReport({
+        activationRoot: "/tmp/activation"
+    });
+
+    assert.deepEqual(globalThis.__statusSummaryCounters.get(), {
+        activePackObservabilityCalls: 1,
+        principalObservabilityCalls: 1
+    });
+    assert.equal(detailedReport.labelFlow.source, "active_pack");
+    assert.equal(detailedReport.learningPath.available, true);
+    assert.equal(detailedReport.principal.available, true);
+
+    delete globalThis.__statusSummaryCounters;
+});
+
 test("current profile status preserves hook packageVersion for hotfix-boundary reporting", () => {
     const buildCurrentProfileBrainStatusFromReport = loadFunction({
         file: "index.js",


### PR DESCRIPTION
## Summary

Plain human `openclawbrain status` now skips detailed-only active-pack and principal surfaces without widening the public API.

- `buildOperatorSurfaceReport(input)` and `describeCurrentProfileBrainStatusWithReport(input)` signatures stay single-argument.
- The CLI tags the input with a non-enumerable private `Symbol.for('@openclawbrain/cli/operatorSurfaceDetailLevel')` marker to request summary mode.
- Plain status skips `summarizeActivePackObservability` and `summarizePrincipalObservability`.
- `--detailed` keeps the full report path.
- Tests updated to verify the internal marker contract.

## Verification

- `node --test packages/cli/dist/test/operator-status-regressions.test.js packages/cli/dist/test/status-single-snapshot.test.js packages/cli/dist/test/install-converge.test.js` → 21/21 passing (2 new tests)

## Context

Builds on #21. The earlier PR cut duplicate full-pack and teacher-snapshot reloads; this follow-up makes plain status genuinely lighter than detailed status.