### PR TITLE
Tighten status summary hot path

### DIFF
--- a/packages/cli/dist/src/cli.js
+++ b/packages/cli/dist/src/cli.js
@@ -1175,7 +1175,44 @@ function runOllamaProbe(args, baseUrl) {
         };
     }
 }
-function summarizeStatusEmbeddings(report, providerConfig) {
+function summarizeStatusEmbeddings(report, providerConfig, options = {}) {
+    if (options.detailed !== true) {
+        const skippedDetail = "summary status skipped active-pack vector inspection and Ollama model probing; rerun `openclawbrain status --detailed` for live embedding proof";
+        if (providerConfig.embedder.provider === "off") {
+            return {
+                provider: providerConfig.embedder.provider,
+                model: providerConfig.embedder.model,
+                provisionedState: "off",
+                liveState: "unknown",
+                embeddedEntryCount: null,
+                totalEntryCount: null,
+                models: [],
+                detail: `${skippedDetail}; embedder provider is off`
+            };
+        }
+        if (providerConfig.embedder.provider === "keywords") {
+            return {
+                provider: providerConfig.embedder.provider,
+                model: providerConfig.embedder.model,
+                provisionedState: "builtin",
+                liveState: "unknown",
+                embeddedEntryCount: null,
+                totalEntryCount: null,
+                models: [],
+                detail: `${skippedDetail}; keyword embedder needs no Ollama model provision`
+            };
+        }
+        return {
+            provider: providerConfig.embedder.provider,
+            model: providerConfig.embedder.model,
+            provisionedState: "not_checked",
+            liveState: "unknown",
+            embeddedEntryCount: null,
+            totalEntryCount: null,
+            models: [],
+            detail: skippedDetail
+        };
+    }
     let embeddedEntryCount = null;
     let totalEntryCount = null;
     let models = [];
@@ -1237,9 +1274,20 @@ function summarizeStatusEmbeddings(report, providerConfig) {
         detail: `${liveDetail}; ollama model check: ${modelProbe.detail}`
     };
 }
-function summarizeStatusLocalLlm(providerConfig) {
-    const detection = runOllamaProbe(["--version"], providerConfig.teacherBaseUrl);
+function summarizeStatusLocalLlm(providerConfig, options = {}) {
     const enabled = providerConfig.teacher.provider === "ollama";
+    if (options.detailed !== true) {
+        return {
+            detected: null,
+            enabled,
+            provider: providerConfig.teacher.provider,
+            model: providerConfig.teacher.model,
+            detail: enabled
+                ? "summary status skipped synchronous Ollama probing; rerun `openclawbrain status --detailed` for live teacher connectivity proof"
+                : `teacher labeling is ${providerConfig.teacher.provider}; summary status skipped synchronous Ollama probing`
+        };
+    }
+    const detection = runOllamaProbe(["--version"], providerConfig.teacherBaseUrl);
     if (enabled) {
         return {
             detected: detection.detected,
@@ -1263,6 +1311,7 @@ function summarizeStatusLocalLlm(providerConfig) {
 }
 function summarizeStatusTeacher(report, providerConfig, localLlm) {
     const enabled = providerConfig.teacher.provider === "ollama";
+    const probeSkipped = localLlm.detected === null;
     const latestCycle = report.teacherLoop.lastNoOpReason === "unavailable"
         ? "unknown"
         : report.teacherLoop.lastNoOpReason === "none"
@@ -1279,7 +1328,7 @@ function summarizeStatusTeacher(report, providerConfig, localLlm) {
             detail: `${providerConfig.teacher.model} is not enabled because teacher labeling is ${providerConfig.teacher.provider}`
         };
     }
-    if (!localLlm.detected) {
+    if (localLlm.detected === false) {
         return {
             model: providerConfig.teacher.model,
             enabled,
@@ -1298,7 +1347,9 @@ function summarizeStatusTeacher(report, providerConfig, localLlm) {
             stale: null,
             idle: null,
             latestCycle,
-            detail: `${providerConfig.teacher.model} is enabled on Ollama, but no watch teacher snapshot is visible yet`
+            detail: probeSkipped
+                ? `${providerConfig.teacher.model} is configured on Ollama, but summary status skipped synchronous probing and no watch teacher snapshot is visible yet`
+                : `${providerConfig.teacher.model} is enabled on Ollama, but no watch teacher snapshot is visible yet`
         };
     }
     const watchState = report.teacherLoop.watch?.state ?? report.teacherLoop.watchState ?? "not_visible";
@@ -1321,8 +1372,12 @@ function summarizeStatusTeacher(report, providerConfig, localLlm) {
             idle,
             latestCycle,
             detail: report.teacherLoop.failureDetail === null
-                ? `${providerConfig.teacher.model} is enabled, but the watch loop recorded ${report.teacherLoop.failureMode}`
-                : `${providerConfig.teacher.model} is enabled, but the watch loop recorded ${report.teacherLoop.failureMode}: ${report.teacherLoop.failureDetail}`
+                ? probeSkipped
+                    ? `${providerConfig.teacher.model} is configured on Ollama; summary status skipped synchronous probing and the watch loop recorded ${report.teacherLoop.failureMode}`
+                    : `${providerConfig.teacher.model} is enabled, but the watch loop recorded ${report.teacherLoop.failureMode}`
+                : probeSkipped
+                    ? `${providerConfig.teacher.model} is configured on Ollama; summary status skipped synchronous probing and the watch loop recorded ${report.teacherLoop.failureMode}: ${report.teacherLoop.failureDetail}`
+                    : `${providerConfig.teacher.model} is enabled, but the watch loop recorded ${report.teacherLoop.failureMode}: ${report.teacherLoop.failureDetail}`
         };
     }
     return {
@@ -1332,9 +1387,13 @@ function summarizeStatusTeacher(report, providerConfig, localLlm) {
         stale,
         idle,
         latestCycle,
-        detail: watchState === "lagging"
-            ? `${providerConfig.teacher.model} is enabled on Ollama, but the watch heartbeat is lagging; ${cycleDetail}`
-            : `${providerConfig.teacher.model} is enabled on Ollama; ${cycleDetail}`
+        detail: probeSkipped
+            ? watchState === "lagging"
+                ? `${providerConfig.teacher.model} is configured on Ollama; summary status skipped synchronous probing, the watch heartbeat is lagging; ${cycleDetail}`
+                : `${providerConfig.teacher.model} is configured on Ollama; summary status skipped synchronous probing; ${cycleDetail}`
+            : watchState === "lagging"
+                ? `${providerConfig.teacher.model} is enabled on Ollama, but the watch heartbeat is lagging; ${cycleDetail}`
+                : `${providerConfig.teacher.model} is enabled on Ollama; ${cycleDetail}`
     };
 }
 function summarizeStatusEmbedder(embeddings) {
@@ -1476,10 +1535,10 @@ function summarizeStatusAlerts(report, providerConfig, embeddings, localLlm) {
     if (providerConfig.warnings.length > 0) {
         pushUniqueAlert(buckets.cosmeticNoise, "provider env warnings forced fallback defaults");
     }
-    if (localLlm.enabled && !localLlm.detected) {
+    if (localLlm.enabled && localLlm.detected === false) {
         pushUniqueAlert(buckets.degradedBrain, "local LLM is enabled but not detected");
     }
-    if (embeddings.provider === "ollama" && embeddings.provisionedState !== "confirmed") {
+    if (embeddings.provider === "ollama" && embeddings.provisionedState === "not_confirmed") {
         pushUniqueAlert(buckets.degradedBrain, `embedder model ${embeddings.model} is not confirmed on Ollama`);
     }
     if (embeddings.provider === "ollama" && embeddings.liveState === "no") {
@@ -1562,12 +1621,13 @@ function formatTracedLearningSurface(surface) {
     return `present=${yesNo(surface.present)} updated=${surface.updatedAt ?? "none"} routes=${surface.routeTraceCount} supervision=${surface.supervisionCount} updates=${surface.routerUpdateCount} teacher=${surface.teacherArtifactCount} pg=${surface.pgVersionUsed ?? "none"} pack=${surface.materializedPackId ?? "none"} detail=${detail}`;
 }
 function buildCompactStatusHeader(status, report, options) {
+    const detailed = options.detailed === true;
     const installHook = summarizeStatusInstallHook(options.openclawHome);
     const hookLoad = summarizeStatusHookLoad(installHook, status);
     const hotfixBoundary = summarizeStatusHotfixBoundary(status);
-    const embeddings = summarizeStatusEmbeddings(report, options.providerConfig);
-    const localLlm = summarizeStatusLocalLlm(options.providerConfig);
-    const teacher = summarizeStatusTeacher(report, options.providerConfig, localLlm);
+    const embeddings = options.embeddings ?? summarizeStatusEmbeddings(report, options.providerConfig, { detailed });
+    const localLlm = options.localLlm ?? summarizeStatusLocalLlm(options.providerConfig, { detailed });
+    const teacher = options.teacher ?? summarizeStatusTeacher(report, options.providerConfig, localLlm);
     const embedder = summarizeStatusEmbedder(embeddings);
     const routeFn = summarizeStatusRouteFn(status, report);
     const alerts = summarizeStatusAlerts(report, options.providerConfig, embeddings, localLlm);
@@ -1609,8 +1669,8 @@ function formatCurrentProfileStatusSummary(status, report, targetInspection, opt
     const installHook = summarizeStatusInstallHook(options.openclawHome);
     const displayedStatus = summarizeDisplayedStatus(status, installHook);
     const hotfixBoundary = summarizeStatusHotfixBoundary(status);
-    const embeddings = summarizeStatusEmbeddings(report, options.providerConfig);
-    const localLlm = summarizeStatusLocalLlm(options.providerConfig);
+    const embeddings = summarizeStatusEmbeddings(report, options.providerConfig, { detailed: true });
+    const localLlm = summarizeStatusLocalLlm(options.providerConfig, { detailed: true });
     const teacher = summarizeStatusTeacher(report, options.providerConfig, localLlm);
     const liveModels = embeddings.models.length === 0 ? "none" : embeddings.models.join("|");
     const attachmentTruth = summarizeStatusAttachmentTruth({
@@ -1625,7 +1685,13 @@ function formatCurrentProfileStatusSummary(status, report, targetInspection, opt
         : `target      activation=${status.host.activationRoot} ${formatOpenClawTargetLine(targetInspection)} hook=${status.hook.hookPath === null ? "unverified" : shortenPath(status.hook.hookPath)}`;
     return [
         `STATUS ${displayedStatus}`,
-        ...buildCompactStatusHeader(status, report, options),
+        ...buildCompactStatusHeader(status, report, {
+            ...options,
+            detailed: true,
+            embeddings,
+            localLlm,
+            teacher
+        }),
         `answer      ${status.brain.summary}`,
         targetLine,
         ...(targetInspection === null ? [] : [`preflight   ${formatOpenClawTargetExplanation(targetInspection)}`]),

--- a/packages/cli/dist/src/index.js
+++ b/packages/cli/dist/src/index.js
@@ -6390,19 +6390,22 @@ function summarizeBrainState(active, observability) {
     };
 }
 function summarizeLatestGraphMaterialization(input, active, activeGraphEvolution) {
-    const loadedTeacherSurface = loadTeacherSurfaceFromInput(input);
-    const latestMaterialization = loadedTeacherSurface?.snapshot.learner.lastMaterialization ?? null;
-    const latestGraph = latestMaterialization?.candidate.summary.graphEvolutionLog ?? null;
-    if (latestGraph !== null) {
-        const packId = latestMaterialization?.candidate.summary.packId ?? latestGraph.packId;
-        return {
-            known: true,
-            packId,
-            changed: latestGraph.structuralEvolutionSummary.changed,
-            connectDiagnostics: latestGraph.connectDiagnostics === null ? null : { ...latestGraph.connectDiagnostics },
-            operatorSummary: latestGraph.structuralEvolutionSummary.operatorSummary,
-            detail: `latest known materialization is ${packId} from the teacher snapshot`
-        };
+    const includeTeacherSnapshot = resolveOperatorSurfaceReportDetailLevel(input) !== "summary";
+    if (includeTeacherSnapshot) {
+        const loadedTeacherSurface = loadTeacherSurfaceFromInput(input);
+        const latestMaterialization = loadedTeacherSurface?.snapshot.learner.lastMaterialization ?? null;
+        const latestGraph = latestMaterialization?.candidate.summary.graphEvolutionLog ?? null;
+        if (latestGraph !== null) {
+            const packId = latestMaterialization?.candidate.summary.packId ?? latestGraph.packId;
+            return {
+                known: true,
+                packId,
+                changed: latestGraph.structuralEvolutionSummary.changed,
+                connectDiagnostics: latestGraph.connectDiagnostics === null ? null : { ...latestGraph.connectDiagnostics },
+                operatorSummary: latestGraph.structuralEvolutionSummary.operatorSummary,
+                detail: `latest known materialization is ${packId} from the teacher snapshot`
+            };
+        }
     }
     if (active !== null && activeGraphEvolution !== null) {
         return {
@@ -6412,6 +6415,16 @@ function summarizeLatestGraphMaterialization(input, active, activeGraphEvolution
             connectDiagnostics: activeGraphEvolution.connectDiagnostics === null ? null : { ...activeGraphEvolution.connectDiagnostics },
             operatorSummary: activeGraphEvolution.structuralEvolutionSummary.operatorSummary,
             detail: `latest known materialization is the active pack ${active.packId}`
+        };
+    }
+    if (!includeTeacherSnapshot && active !== null) {
+        return {
+            known: true,
+            packId: active.packId,
+            changed: null,
+            connectDiagnostics: null,
+            operatorSummary: null,
+            detail: `summary status uses the active pack ${active.packId} as the latest cheap local graph truth`
         };
     }
     return {
@@ -6757,6 +6770,31 @@ function buildSummaryOnlyPrincipalObservability(active) {
             note: detail
         },
         servingDownstreamOfLatestCorrection: null,
+        detail
+    };
+}
+function buildSummaryOnlySupervision(active) {
+    const detail = "summary status skipped event-export supervision inspection; rerun `openclawbrain status --detailed` when you need local supervision and attribution proof";
+    return {
+        available: false,
+        sourcePath: null,
+        sourceKind: "summary_only",
+        exportDigest: active?.eventExportDigest ?? null,
+        exportedAt: null,
+        flowing: null,
+        scanPolicy: null,
+        scanSurfaceCount: 0,
+        scanSurfaces: [],
+        sourceCount: 0,
+        freshestSourceStream: null,
+        freshestCreatedAt: null,
+        freshestKind: null,
+        humanLabelCount: null,
+        selfLabelCount: null,
+        attributedEventCount: null,
+        totalEventCount: null,
+        selectionDigestCount: null,
+        sources: [],
         detail
     };
 }
@@ -7531,6 +7569,44 @@ function summarizeAlwaysOnLearning(input, active) {
                             : "learner is waiting for the first export"
     };
 }
+function buildSummaryOnlyAlwaysOnLearning(active) {
+    const detail = "summary status skipped teacher backlog inspection; rerun `openclawbrain status --detailed` when you need learner queue and principal lag proof";
+    return {
+        available: false,
+        sourcePath: null,
+        bootstrapped: null,
+        mode: "unavailable",
+        nextPriorityLane: "unavailable",
+        nextPriorityBucket: "unavailable",
+        backlogState: "unavailable",
+        pendingLive: null,
+        pendingBackfill: null,
+        pendingTotal: null,
+        pendingByBucket: null,
+        freshLivePriority: null,
+        principalCheckpointCount: null,
+        pendingPrincipalCount: null,
+        oldestUnlearnedPrincipalEvent: null,
+        newestPendingPrincipalEvent: null,
+        leadingPrincipalCheckpoint: null,
+        principalCheckpoints: [],
+        principalLagToPromotion: {
+            activeEventRangeEnd: active?.eventRange.end ?? null,
+            latestPrincipalSequence: null,
+            sequenceLag: null,
+            status: "unavailable"
+        },
+        warningStates: [],
+        learnedRange: null,
+        materializationCount: null,
+        lastMaterializedAt: null,
+        lastMaterializationReason: null,
+        lastMaterializationLane: null,
+        lastMaterializationPriority: null,
+        lastMaterializedPackId: null,
+        detail
+    };
+}
 function buildOperatorFindings(report) {
     const findings = [];
     const push = (severity, code, summary, detail) => {
@@ -7628,7 +7704,12 @@ function buildOperatorFindings(report) {
         push("warn", "rollback_blocked", "rollback is not ready", report.rollback.findings.join("; ") || "previous pointer is missing or no rollback target is retained");
     }
     if (!report.supervision.available) {
-        push("warn", "supervision_unavailable", "supervision flow is not inspectable yet", "pass `--event-export <bundle-root-or-payload>` to inspect local supervision freshness");
+        if (report.supervision.sourceKind === "summary_only") {
+            // Plain summary intentionally skips event-export inspection.
+        }
+        else {
+            push("warn", "supervision_unavailable", "supervision flow is not inspectable yet", "pass `--event-export <bundle-root-or-payload>` to inspect local supervision freshness");
+        }
     }
     else if (report.supervision.flowing) {
         push("pass", "supervision_visible", `supervision is flowing through ${report.supervision.freshestSourceStream ?? "unknown-source"}`, `freshest=${report.supervision.freshestCreatedAt ?? "unknown"}; humanLabels=${report.supervision.humanLabelCount ?? 0}`);
@@ -7762,7 +7843,7 @@ function summarizeCurrentProfilePassiveLearning(report, activePackId) {
         pendingBackfill: report.learning.available ? report.learning.pendingBackfill : null,
         lastWatchHeartbeatAt: watch.lastHeartbeatAt ?? report.teacherLoop.lastHeartbeatAt,
         watchIntervalSeconds: watch.intervalSeconds ?? report.teacherLoop.pollIntervalSeconds,
-        lastExportAt: report.supervision.exportedAt,
+        lastExportAt: report.supervision.exportedAt ?? report.teacherLoop.lastProcessedAt,
         lastPromotionAt: report.promotion.lastPromotion.at,
         currentServingPackId: activePackId,
         lastMaterializedPackId: report.learning.lastMaterializedPackId ?? report.teacherLoop.lastMaterializedPackId,
@@ -8091,10 +8172,8 @@ function buildOperatorSurfaceReportWithDetailLevel(input, detailLevel) {
     const cachedInput = {
         ...input,
         activationRoot,
-        teacherSnapshotPath: resolvedTeacherSnapshotPath,
-        __loadedTeacherSurface: resolvedTeacherSnapshotPath === null ? null : loadTeacherSurface(resolvedTeacherSnapshotPath)
+        teacherSnapshotPath: resolvedTeacherSnapshotPath
     };
-    cachedInput.__loadedOperatorEventExport = loadOperatorEventExport(cachedInput);
     const packCache = new Map();
     let inspection = null;
     let observability = null;
@@ -8218,8 +8297,12 @@ function buildOperatorSurfaceReportWithDetailLevel(input, detailLevel) {
             previousPackId: inspection?.previous?.packId ?? inspection?.pointers.previous?.packId ?? null,
             state: inspection === null ? "unknown" : inspection.rollback.allowed ? "ready" : inspection.active === null ? "unknown" : "blocked"
         },
-        supervision: summarizeSupervision(cachedInput),
-        learning: summarizeAlwaysOnLearning(cachedInput, active),
+        supervision: detailLevel === "summary"
+            ? buildSummaryOnlySupervision(active)
+            : summarizeSupervision(cachedInput),
+        learning: detailLevel === "summary"
+            ? buildSummaryOnlyAlwaysOnLearning(active)
+            : summarizeAlwaysOnLearning(cachedInput, active),
         teacherLoop,
         routeFn,
         hook,

--- a/packages/cli/dist/test/operator-status-regressions.test.js
+++ b/packages/cli/dist/test/operator-status-regressions.test.js
@@ -229,3 +229,101 @@ test("resolveActivationCompileTarget accepts a preloaded pack without reopening 
     assert.equal(resolved.target, target);
     assert.equal(resolved.slot, "active");
 });
+
+test("summary graph materialization falls back to active-pack truth without loading the teacher snapshot", () => {
+    const summarizeLatestGraphMaterialization = loadFunctionFromSourcePath({
+        sourcePath: path.join(__dirname, "..", "src", "index.js"),
+        startMarker: "function summarizeLatestGraphMaterialization",
+        endMarker: "function summarizeGraphObservability",
+        prelude: `
+            function resolveOperatorSurfaceReportDetailLevel() {
+                return "summary";
+            }
+            function loadTeacherSurfaceFromInput() {
+                throw new Error("summary graph truth should not load the teacher snapshot");
+            }
+        `
+    });
+    const result = summarizeLatestGraphMaterialization({}, { packId: "pack-active" }, null);
+    assert.deepEqual(result, {
+        known: true,
+        packId: "pack-active",
+        changed: null,
+        connectDiagnostics: null,
+        operatorSummary: null,
+        detail: "summary status uses the active pack pack-active as the latest cheap local graph truth"
+    });
+});
+
+test("summary status embeddings skip vector inspection and Ollama model probing", () => {
+    const summarizeStatusEmbeddings = loadFunctionFromSourcePath({
+        sourcePath: path.join(__dirname, "..", "src", "cli.js"),
+        startMarker: "function summarizeStatusEmbeddings",
+        endMarker: "function summarizeStatusLocalLlm",
+        prelude: `
+            let packLoads = 0;
+            let probeCalls = 0;
+            function loadPackFromActivation() {
+                packLoads += 1;
+                return null;
+            }
+            function summarizePackVectorEmbeddingState() {
+                throw new Error("summary status should not inspect vectors");
+            }
+            function runOllamaProbe() {
+                probeCalls += 1;
+                return { detected: true, detail: "ollama responded" };
+            }
+            function toErrorMessage(error) {
+                return error instanceof Error ? error.message : String(error);
+            }
+            globalThis.__summaryEmbeddingCounters = () => ({ packLoads, probeCalls });
+        `
+    });
+    const result = summarizeStatusEmbeddings({
+        active: { activationReady: true },
+        activationRoot: "/tmp/activation"
+    }, {
+        embedder: {
+            provider: "ollama",
+            model: "nomic-embed-text"
+        },
+        embedderBaseUrl: "http://127.0.0.1:11434"
+    });
+    assert.equal(result.provisionedState, "not_checked");
+    assert.equal(result.liveState, "unknown");
+    assert.match(result.detail, /skipped active-pack vector inspection and Ollama model probing/);
+    assert.deepEqual(globalThis.__summaryEmbeddingCounters(), {
+        packLoads: 0,
+        probeCalls: 0
+    });
+    delete globalThis.__summaryEmbeddingCounters;
+});
+
+test("summary status local LLM surface skips synchronous Ollama probing", () => {
+    const summarizeStatusLocalLlm = loadFunctionFromSourcePath({
+        sourcePath: path.join(__dirname, "..", "src", "cli.js"),
+        startMarker: "function summarizeStatusLocalLlm",
+        endMarker: "function summarizeStatusTeacher",
+        prelude: `
+            let probeCalls = 0;
+            function runOllamaProbe() {
+                probeCalls += 1;
+                return { detected: true, detail: "ollama responded" };
+            }
+            globalThis.__summaryLocalLlmProbeCalls = () => probeCalls;
+        `
+    });
+    const result = summarizeStatusLocalLlm({
+        teacher: {
+            provider: "ollama",
+            model: "qwen3.5:14b"
+        },
+        teacherBaseUrl: "http://127.0.0.1:11434"
+    });
+    assert.equal(result.detected, null);
+    assert.equal(result.enabled, true);
+    assert.match(result.detail, /skipped synchronous Ollama probing/);
+    assert.equal(globalThis.__summaryLocalLlmProbeCalls(), 0);
+    delete globalThis.__summaryLocalLlmProbeCalls;
+});

--- a/packages/cli/dist/test/status-single-snapshot.test.js
+++ b/packages/cli/dist/test/status-single-snapshot.test.js
@@ -144,9 +144,11 @@ test("summary operator status report skips detailed-only active-pack and princip
                 return null;
             }
             function loadTeacherSurface() {
+                teacherSurfaceLoadCalls += 1;
                 return null;
             }
             function loadOperatorEventExport() {
+                eventExportLoadCalls += 1;
                 return null;
             }
             function inspectActivationState() {
@@ -521,7 +523,32 @@ test("summary operator status report skips detailed-only active-pack and princip
             function summarizeCandidateAheadBy() {
                 return [];
             }
+            function buildSummaryOnlySupervision() {
+                return {
+                    available: false,
+                    sourcePath: null,
+                    sourceKind: "summary_only",
+                    exportDigest: null,
+                    exportedAt: null,
+                    flowing: null,
+                    scanPolicy: null,
+                    scanSurfaceCount: 0,
+                    scanSurfaces: [],
+                    sourceCount: 0,
+                    freshestSourceStream: null,
+                    freshestCreatedAt: null,
+                    freshestKind: null,
+                    humanLabelCount: null,
+                    selfLabelCount: null,
+                    attributedEventCount: null,
+                    totalEventCount: null,
+                    selectionDigestCount: null,
+                    sources: [],
+                    detail: "summary-only supervision"
+                };
+            }
             function summarizeSupervision() {
+                supervisionCalls += 1;
                 return {
                     available: false,
                     sourcePath: null,
@@ -545,7 +572,45 @@ test("summary operator status report skips detailed-only active-pack and princip
                     detail: "no event export"
                 };
             }
+            function buildSummaryOnlyAlwaysOnLearning() {
+                return {
+                    available: false,
+                    sourcePath: null,
+                    bootstrapped: null,
+                    mode: "unavailable",
+                    nextPriorityLane: "unavailable",
+                    nextPriorityBucket: "unavailable",
+                    backlogState: "unavailable",
+                    pendingLive: null,
+                    pendingBackfill: null,
+                    pendingTotal: null,
+                    pendingByBucket: null,
+                    freshLivePriority: null,
+                    principalCheckpointCount: null,
+                    pendingPrincipalCount: null,
+                    oldestUnlearnedPrincipalEvent: null,
+                    newestPendingPrincipalEvent: null,
+                    leadingPrincipalCheckpoint: null,
+                    principalCheckpoints: [],
+                    principalLagToPromotion: {
+                        activeEventRangeEnd: null,
+                        latestPrincipalSequence: null,
+                        sequenceLag: null,
+                        status: "unavailable"
+                    },
+                    warningStates: [],
+                    learnedRange: null,
+                    materializationCount: null,
+                    lastMaterializedAt: null,
+                    lastMaterializationReason: null,
+                    lastMaterializationLane: null,
+                    lastMaterializationPriority: null,
+                    lastMaterializedPackId: null,
+                    detail: "summary-only learning"
+                };
+            }
             function summarizeAlwaysOnLearning() {
+                learningCalls += 1;
                 return {
                     available: false,
                     sourcePath: null,
@@ -617,16 +682,28 @@ test("summary operator status report skips detailed-only active-pack and princip
             function summarizeOperatorStatus() {
                 return "ok";
             }
+            let teacherSurfaceLoadCalls = 0;
+            let eventExportLoadCalls = 0;
+            let supervisionCalls = 0;
+            let learningCalls = 0;
             globalThis.__statusSummaryCounters = {
                 get() {
                     return {
                         activePackObservabilityCalls,
-                        principalObservabilityCalls
+                        principalObservabilityCalls,
+                        teacherSurfaceLoadCalls,
+                        eventExportLoadCalls,
+                        supervisionCalls,
+                        learningCalls
                     };
                 },
                 reset() {
                     activePackObservabilityCalls = 0;
                     principalObservabilityCalls = 0;
+                    teacherSurfaceLoadCalls = 0;
+                    eventExportLoadCalls = 0;
+                    supervisionCalls = 0;
+                    learningCalls = 0;
                 }
             };
         `
@@ -645,11 +722,17 @@ test("summary operator status report skips detailed-only active-pack and princip
 
     assert.deepEqual(globalThis.__statusSummaryCounters.get(), {
         activePackObservabilityCalls: 0,
-        principalObservabilityCalls: 0
+        principalObservabilityCalls: 0,
+        teacherSurfaceLoadCalls: 0,
+        eventExportLoadCalls: 0,
+        supervisionCalls: 0,
+        learningCalls: 0
     });
     assert.equal(summaryReport.labelFlow.source, "missing");
     assert.equal(summaryReport.learningPath.available, false);
     assert.equal(summaryReport.principal.available, false);
+    assert.equal(summaryReport.supervision.sourceKind, "summary_only");
+    assert.deepEqual(summaryReport.learning.warningStates, []);
 
     globalThis.__statusSummaryCounters.reset();
     const detailedReport = buildOperatorSurfaceReport({
@@ -658,7 +741,11 @@ test("summary operator status report skips detailed-only active-pack and princip
 
     assert.deepEqual(globalThis.__statusSummaryCounters.get(), {
         activePackObservabilityCalls: 1,
-        principalObservabilityCalls: 1
+        principalObservabilityCalls: 1,
+        teacherSurfaceLoadCalls: 0,
+        eventExportLoadCalls: 0,
+        supervisionCalls: 1,
+        learningCalls: 1
     });
     assert.equal(detailedReport.labelFlow.source, "active_pack");
     assert.equal(detailedReport.learningPath.available, true);

--- a/packages/cli/dist/test/teacher-status-truth.test.js
+++ b/packages/cli/dist/test/teacher-status-truth.test.js
@@ -123,6 +123,18 @@ test("status teacher stays healthy for a fresh watch heartbeat with no teacher a
     assert.match(summary.detail, /no eligible feedback, operator overrides, or matched interaction text/);
 });
 
+test("status teacher can rely on watch truth when summary skips synchronous Ollama probing", () => {
+    const summary = summarizeStatusTeacher(makeTeacherReport({
+        latestFreshness: "fresh",
+        watchState: "watching"
+    }), providerConfig, { detected: null });
+    assert.equal(summary.enabled, true);
+    assert.equal(summary.healthy, true);
+    assert.equal(summary.stale, false);
+    assert.equal(summary.idle, true);
+    assert.match(summary.detail, /summary status skipped synchronous probing/);
+});
+
 test("status teacher stays unhealthy when the watch snapshot itself is stale", () => {
     const summary = summarizeStatusTeacher(makeTeacherReport({
         latestFreshness: "fresh",


### PR DESCRIPTION
## Summary
- keep plain `openclawbrain status` on cheap local truth instead of eagerly loading detailed-only teacher and supervision surfaces
- skip synchronous Ollama probing and active-pack vector inspection on summary status while preserving detailed status behavior
- add focused regressions so summary status stays lighter without widening the public API

## Testing
- node --test packages/cli/dist/test/operator-status-regressions.test.js packages/cli/dist/test/status-single-snapshot.test.js packages/cli/dist/test/teacher-status-truth.test.js