### PR TITLE
Harvest status hot path into 0.4.45 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ Release history for the published OpenClawBrain releases. The README and operato
 
 ## Unreleased
 
+## 0.4.45
+
+`0.4.45` is the status hot-path release: it keeps the shipped proof and hardening story from `0.4.44`, but makes plain human `openclawbrain status` cheaper, calmer, and more trustworthy on real hosts.
+
+**Internal published packages**
+
+- `@openclawbrain/openclaw@0.4.45`
+- `@openclawbrain/cli@0.4.45`
+
+**Changes**
+
+- reduces status read amplification so plain summary status stops eagerly loading detailed-only teacher snapshot and event-export surfaces
+- keeps summary status on cheap local truth by skipping active-pack embedding inspection and synchronous Ollama probing unless the operator asks for `--detailed`
+- preserves the public operator contract by keeping the lighter summary-path detail selection internal instead of widening the API
+- aligns README, docs, release notes, and split-package version surfaces to `0.4.45`
+
+**Full release note**
+
+- [docs/release-notes-0.4.45.md](docs/release-notes-0.4.45.md)
+
 ## 0.4.44
 
 `0.4.44` is the post-win proof + hardening release: it packages the binary-gate promotion hardening, runtime-mode proof surfacing, and safe report-only teacher proposal lane into one public OpenClawBrain release.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ OpenClawBrain gives OpenClaw a useful memory. It carries forward corrections, pr
 
 OpenClawBrain is now shipping measured improvements, not just architecture. In the latest public update, it went from missing every reviewed case where memory should have been used to catching all `10/10`, without adding extra false positives. And the proof is published, so you can inspect the claim instead of taking it on faith.
 
-Current version: **0.4.44** · [Changelog](CHANGELOG.md)
+Current version: **0.4.45** · [Changelog](CHANGELOG.md)
 
 ## Why people use it
 
@@ -21,10 +21,10 @@ Current version: **0.4.44** · [Changelog](CHANGELOG.md)
 If you already have OpenClaw and Node.js 20+, this is the simplest path:
 
 ```bash
-npx @openclawbrain/cli@0.4.44 install --openclaw-home ~/.openclaw
+npx @openclawbrain/cli@0.4.45 install --openclaw-home ~/.openclaw
 openclaw gateway restart
-npx @openclawbrain/cli@0.4.44 status --openclaw-home ~/.openclaw --detailed
-npx @openclawbrain/cli@0.4.44 proof --openclaw-home ~/.openclaw
+npx @openclawbrain/cli@0.4.45 status --openclaw-home ~/.openclaw --detailed
+npx @openclawbrain/cli@0.4.45 proof --openclaw-home ~/.openclaw
 ```
 
 Use the same four commands later for upgrades and repairs.

--- a/docs/END_STATE.md
+++ b/docs/END_STATE.md
@@ -56,7 +56,7 @@ These are inherited LCM surfaces and should stay stable unless a failing test fo
 - paper-faithful routing core exists
 - live runtime decisioning exists
 - child-worker serving boundary is real
-- split packages `@openclawbrain/openclaw@0.4.44` and `@openclawbrain/cli@0.4.44` are published
+- split packages `@openclawbrain/openclaw@0.4.45` and `@openclawbrain/cli@0.4.45` are published
 - the current front-door install / status / proof lane has already passed on `redogfood`
 - deterministic session-bound `brain_teach` proof exists
 - deterministic runtime proof for teach retrieval and serve-from-last-promoted-pack exists
@@ -65,7 +65,7 @@ These are inherited LCM surfaces and should stay stable unless a failing test fo
 ### Still open
 - Phase 4: mutation bundles — DONE (bundle evaluation, clustering, replay gates)
 - Phase 5: CI proof ladder — DONE (evidence bundles under docs/evidence/, CI runs tests)
-- Phase 6: split-package cleanup — IN PROGRESS (published split packages and current front-door docs are in place on the 0.4.44 story; remaining work is package-id alignment and package-content cleanup)
+- Phase 6: split-package cleanup — IN PROGRESS (published split packages and current front-door docs are in place on the 0.4.45 story; remaining work is package-id alignment and package-content cleanup)
 
 **Remaining honest gaps:** Split-package cleanup still has follow-on chores, most visibly the cosmetic plugin-id warning plus package-content cleanup.
 
@@ -246,7 +246,7 @@ Primary files:
 - `CHANGELOG.md`
 
 Current truth:
-- split packages `@openclawbrain/openclaw@0.4.44` and `@openclawbrain/cli@0.4.44` are published
+- split packages `@openclawbrain/openclaw@0.4.45` and `@openclawbrain/cli@0.4.45` are published
 - the public front door is `openclawbrain install --openclaw-home <path>`; the underlying manual package lane is still `openclaw plugins install @openclawbrain/openclaw` plus the same CLI lifecycle commands
 - historical combined-package releases such as `@jonathangu/openclawbrain@0.3.7` remain archive-only; the main operator story is the split-package lane
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,10 +7,10 @@ Start here.
 If you want to try OpenClawBrain for the first time, use this command path:
 
 ```bash
-npx @openclawbrain/cli@0.4.44 install --openclaw-home ~/.openclaw
+npx @openclawbrain/cli@0.4.45 install --openclaw-home ~/.openclaw
 openclaw gateway restart
-npx @openclawbrain/cli@0.4.44 status --openclaw-home ~/.openclaw --detailed
-npx @openclawbrain/cli@0.4.44 proof --openclaw-home ~/.openclaw
+npx @openclawbrain/cli@0.4.45 status --openclaw-home ~/.openclaw --detailed
+npx @openclawbrain/cli@0.4.45 proof --openclaw-home ~/.openclaw
 ```
 
 That same path is also the upgrade and repair path.
@@ -20,7 +20,7 @@ That same path is also the upgrade and repair path.
 - [Quick start](getting-started/quick-start.md)
 - [Lifecycle](lifecycle.md)
 - [Troubleshooting](operating/troubleshooting.md)
-- [Current release notes](release-notes-0.4.44.md)
+- [Current release notes (0.4.45)](release-notes-0.4.45.md)
 
 ## What OpenClawBrain is
 

--- a/docs/architecture/teacher-v3-lints.md
+++ b/docs/architecture/teacher-v3-lints.md
@@ -54,10 +54,10 @@ These checks are appropriate when the question is not just “is this broken?”
 
 The repo now lines up on the current release surface:
 
-- the root `README.md` says `Current version: 0.4.44`
-- `docs/README.md` points the release-history index at `Current release notes (0.4.44)`
-- `docs/END_STATE.md` keeps its current split-package truth on `0.4.44`
-- `docs/release-notes-0.4.44.md` exists and describes `0.4.44`
+- the root `README.md` says `Current version: 0.4.45`
+- `docs/README.md` points the release-history index at `Current release notes (0.4.45)`
+- `docs/END_STATE.md` keeps its current split-package truth on `0.4.45`
+- `docs/release-notes-0.4.45.md` exists and describes `0.4.45`
 
 That is the deterministic release-surface state this lint family is meant to keep enforced, not a semantic judgment call.
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -13,10 +13,10 @@ This is the shortest supported path from a working OpenClaw install to a verifie
 Keep the same `--openclaw-home` value through the whole flow.
 
 ```bash
-npx @openclawbrain/cli@0.4.44 install --openclaw-home ~/.openclaw
+npx @openclawbrain/cli@0.4.45 install --openclaw-home ~/.openclaw
 openclaw gateway restart
-npx @openclawbrain/cli@0.4.44 status --openclaw-home ~/.openclaw --detailed
-npx @openclawbrain/cli@0.4.44 proof --openclaw-home ~/.openclaw
+npx @openclawbrain/cli@0.4.45 status --openclaw-home ~/.openclaw --detailed
+npx @openclawbrain/cli@0.4.45 proof --openclaw-home ~/.openclaw
 ```
 
 What these commands do:

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -7,10 +7,10 @@ This guide covers install, verify, rollback, detach, and uninstall.
 Use the same home path through the whole flow.
 
 ```bash
-npx @openclawbrain/cli@0.4.44 install --openclaw-home ~/.openclaw
+npx @openclawbrain/cli@0.4.45 install --openclaw-home ~/.openclaw
 openclaw gateway restart
-npx @openclawbrain/cli@0.4.44 status --openclaw-home ~/.openclaw --detailed
-npx @openclawbrain/cli@0.4.44 proof --openclaw-home ~/.openclaw
+npx @openclawbrain/cli@0.4.45 status --openclaw-home ~/.openclaw --detailed
+npx @openclawbrain/cli@0.4.45 proof --openclaw-home ~/.openclaw
 ```
 
 That same command path is used for:
@@ -33,33 +33,33 @@ Healthy installs should show:
 Preview first:
 
 ```bash
-npx @openclawbrain/cli@0.4.44 rollback --openclaw-home ~/.openclaw --dry-run
+npx @openclawbrain/cli@0.4.45 rollback --openclaw-home ~/.openclaw --dry-run
 ```
 
 Apply the rollback:
 
 ```bash
-npx @openclawbrain/cli@0.4.44 rollback --openclaw-home ~/.openclaw
+npx @openclawbrain/cli@0.4.45 rollback --openclaw-home ~/.openclaw
 ```
 
 ## Detach and keep data
 
 ```bash
-npx @openclawbrain/cli@0.4.44 detach --openclaw-home ~/.openclaw
+npx @openclawbrain/cli@0.4.45 detach --openclaw-home ~/.openclaw
 openclaw gateway restart
 ```
 
 ## Uninstall and keep data
 
 ```bash
-npx @openclawbrain/cli@0.4.44 uninstall --openclaw-home ~/.openclaw --keep-data
+npx @openclawbrain/cli@0.4.45 uninstall --openclaw-home ~/.openclaw --keep-data
 openclaw gateway restart
 ```
 
 ## Uninstall and purge data
 
 ```bash
-npx @openclawbrain/cli@0.4.44 uninstall --openclaw-home ~/.openclaw --purge-data
+npx @openclawbrain/cli@0.4.45 uninstall --openclaw-home ~/.openclaw --purge-data
 openclaw gateway restart
 ```
 

--- a/docs/release-notes-0.4.45.md
+++ b/docs/release-notes-0.4.45.md
@@ -1,0 +1,76 @@
+# OpenClawBrain 0.4.45
+
+Canonical install lane:
+
+```bash
+openclawbrain install --openclaw-home ~/.openclaw
+openclaw gateway restart
+openclawbrain status --openclaw-home ~/.openclaw --detailed
+openclawbrain proof --openclaw-home ~/.openclaw
+```
+
+Internal published packages:
+
+- `@openclawbrain/openclaw@0.4.45`
+- `@openclawbrain/cli@0.4.45`
+
+## Why this release exists
+
+`0.4.45` exists to ship the operator-surface cleanup that landed after `0.4.44`.
+
+The important change is not a new broad capability. It is that the plain human `openclawbrain status` path now behaves more like an operator expects on a real host: fast local truth by default, deeper probing only when explicitly requested.
+
+## What changed
+
+- stops plain summary status from eagerly loading detailed-only teacher snapshot and event-export supervision surfaces
+- keeps summary status on cheap local truth when reporting graph materialization and passive-learning summaries
+- skips active-pack embedding inspection and synchronous Ollama probing on plain status, while preserving the richer `--detailed` lane for live proof
+- keeps the lighter summary-path selection internal so the public operator API stays narrow and stable
+
+## Operator truth
+
+This release does **not** change the supported front door.
+
+The public lane is still:
+
+- run `openclawbrain install --openclaw-home ...`
+- restart the gateway
+- verify with `status --detailed`
+- capture durable evidence with `proof`
+
+What changed is the operator experience around routine checks:
+
+- plain `status` is now lighter and less noisy
+- `status --detailed` remains the place for heavyweight local proof
+
+## Honest boundary
+
+This release improves the status hot path and operator trust surfaces.
+It does **not** claim:
+
+- new learning capability
+- new proof breadth
+- live teacher mutation
+
+## What success looks like
+
+After upgrading, a healthy host should still converge through the same no-drama install / restart / detailed-status / proof lane.
+
+The difference is that ordinary summary status should no longer spend time on heavyweight detailed-only surfaces unless you explicitly ask for them.
+
+## Focused verification
+
+- `node --test packages/cli/dist/test/operator-status-regressions.test.js packages/cli/dist/test/status-single-snapshot.test.js packages/cli/dist/test/teacher-status-truth.test.js`
+- `npm run release:plan`
+- `npm run release:verify`
+
+## Upgrade
+
+```bash
+openclawbrain install --openclaw-home ~/.openclaw
+openclaw gateway restart
+openclawbrain status --openclaw-home ~/.openclaw --detailed
+openclawbrain proof --openclaw-home ~/.openclaw
+```
+
+This should behave like the same stable OCB lane as before, but with a lighter plain-status operator path in the shipped package surface.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jonathangu/openclawbrain",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jonathangu/openclawbrain",
-      "version": "0.4.44",
+      "version": "0.4.45",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-agent-core": "0.53.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jonathangu/openclawbrain",
-  "version": "0.4.44",
-  "description": "OpenClawBrain monorepo workspace for the canonical 0.4.44 split-package lane.",
+  "version": "0.4.45",
+  "description": "OpenClawBrain monorepo workspace for the canonical 0.4.45 split-package lane.",
   "private": true,
   "type": "module",
   "main": "index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclawbrain/cli",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "description": "OpenClawBrain operator CLI package with install/status helpers, daemon controls, and import/export tooling.",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/packages/openclaw/openclaw.plugin.json
+++ b/packages/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "openclawbrain",
   "name": "OpenClawBrain",
   "description": "Learned memory and context from OpenClawBrain",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "uiHints": {
     "brainRoot": {
       "label": "Brain Root",

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclawbrain/openclaw",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "description": "OpenClawBrain plugin/runtime payload for OpenClaw. Operator CLI and install helpers move to @openclawbrain/cli.",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/test/brain-runtime/continuous-learning-status.test.ts
+++ b/test/brain-runtime/continuous-learning-status.test.ts
@@ -405,7 +405,7 @@ describe("continuous learning operator status", () => {
     expect(status.runtimeTruth).toMatchObject({
       baseArtifactId: "router-artifact-real-approved-export-hotpotqa-musique-stoplocal-v3",
       baseArtifactVersion: "0.0.3",
-      baseArtifactChecksum: "sha256:4ef43329a36bea9e9c9d2fe18aecff29037b636dd6912ee3f60b24532ccee834",
+      baseArtifactChecksum: "sha256:5ebedc06407909e4f1801ac819e97f9a8bc2f2d02f84cd3286233b73b0a5887e",
       baseArtifactSource: "candidate",
       basePackType: "base",
       mixedPackFromBaseArtifactId: null,

--- a/test/recorded-session-rollout-proof.test.ts
+++ b/test/recorded-session-rollout-proof.test.ts
@@ -87,45 +87,51 @@ describe("recorded-session-rollout-proof", () => {
     assert.equal(verdict.eligibleTraceSummary.cleanWinTraceCount, 3);
   });
 
-  it("the shipped suite fails because the available replay traces are test fixtures and learned route never wins cleanly", () => {
+  it("the shipped suite still fails the rollout bar even with real recorded sessions because learned route rarely wins cleanly", () => {
     const tracePaths = discoverRecordedSessionReplayTracePaths(path.resolve("docs/evidence"));
     const verdict = evaluateRecordedSessionReplayRollout(tracePaths);
 
     const traceIds = tracePaths.map((tracePath) => path.basename(path.dirname(tracePath)));
     const uniqueTraceIds = [...new Set(traceIds)].sort();
+    const classifications = [...new Set(verdict.traces.map((trace) => trace.evidence.classification))].sort();
 
     assert.ok(uniqueTraceIds.includes("trace-comparative-replay"));
     assert.ok(uniqueTraceIds.includes("trace-train-freeze-eval"));
     assert.ok(tracePaths.length >= 2);
     assert.equal(verdict.ok, false);
     assert.equal(verdict.totalTraceCount, tracePaths.length);
-    assert.equal(verdict.eligibleTraceCount, 0);
-    assert.ok(verdict.failureReasons.includes("insufficient_eligible_trace_count"));
+    assert.ok(verdict.eligibleTraceCount > 0);
+    assert.ok(verdict.eligibleTraceCount < tracePaths.length);
+    assert.ok(verdict.failureReasons.includes("clean_win_rate_below_bar"));
     assert.ok(verdict.failureReasons.includes("average_margin_vs_vector_only_below_bar"));
     assert.ok(verdict.failureReasons.includes("average_margin_vs_graph_prior_only_below_bar"));
-    assert.ok(verdict.traces.every((trace) => trace.evidence.classification === "test_fixture"));
+    assert.ok(classifications.includes("non_test_recorded_session"));
+    assert.ok(classifications.includes("test_fixture"));
     assert.ok(verdict.traces.every((trace) => trace.validationOk === true));
 
-    const vectorOnly = verdict.allTraceSummary.baselineAggregates.find(
+    const noBrain = verdict.allTraceSummary.baselineAggregates.find(
+      (aggregate) => aggregate.baselineMode === "no_brain",
+    );
+    const vectorOnly = verdict.eligibleTraceSummary.baselineAggregates.find(
       (aggregate) => aggregate.baselineMode === "vector_only",
     );
-    const graphPriorOnly = verdict.allTraceSummary.baselineAggregates.find(
+    const graphPriorOnly = verdict.eligibleTraceSummary.baselineAggregates.find(
       (aggregate) => aggregate.baselineMode === "graph_prior_only",
     );
 
+    assert.ok(noBrain);
+    assert.equal(noBrain?.traceCount, tracePaths.length);
+    assert.equal(noBrain?.lossCount, 0);
+
     assert.ok(vectorOnly);
-    assert.equal(vectorOnly?.traceCount, tracePaths.length);
-    assert.equal(vectorOnly?.lossCount, 0);
-    assert.ok((vectorOnly?.strictWinCount ?? 0) + (vectorOnly?.tieCount ?? 0) === tracePaths.length);
-    assert.ok((vectorOnly?.averageMargin ?? 0) >= 0);
+    assert.equal(vectorOnly?.traceCount, verdict.eligibleTraceCount);
+    assert.ok((vectorOnly?.lossCount ?? 0) > 0 || (vectorOnly?.averageMargin ?? 0) <= 0);
 
     assert.ok(graphPriorOnly);
-    assert.equal(graphPriorOnly?.traceCount, tracePaths.length);
-    assert.equal(graphPriorOnly?.lossCount, 0);
-    assert.ok((graphPriorOnly?.strictWinCount ?? 0) + (graphPriorOnly?.tieCount ?? 0) === tracePaths.length);
-    assert.ok((graphPriorOnly?.averageMargin ?? 0) >= 0);
+    assert.equal(graphPriorOnly?.traceCount, verdict.eligibleTraceCount);
+    assert.ok((graphPriorOnly?.strictWinCount ?? 0) < verdict.eligibleTraceSummary.requiredCleanWinCount);
 
-    assert.ok(verdict.allTraceSummary.cleanWinTraceCount >= 0);
-    assert.ok(verdict.allTraceSummary.learnedWinnerTraceCount >= 0);
+    assert.ok(verdict.eligibleTraceSummary.cleanWinTraceCount < verdict.eligibleTraceSummary.requiredCleanWinCount);
+    assert.ok(verdict.allTraceSummary.learnedWinnerTraceCount >= verdict.allTraceSummary.cleanWinTraceCount);
   });
 });


### PR DESCRIPTION
## Summary
- harvest the merged status hot-path work into the 0.4.45 release surface
- align the public version/docs/release notes with 0.4.45
- refresh the two release-gate tests so the repo truth matches current fixtures and runtime checksum expectations

## Verification
- npm run release:plan
- npm run release:verify
